### PR TITLE
feat: OpenDartReader 기반 DART 공시 MCP 서버 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -53,6 +53,9 @@ TAVILY_API_KEY=
 # Alpha Vantage (alternative financial data MCP server, disabled by default)
 ALPHA_VANTAGE_API_KEY=
 
+# FORK: DART (Korean electronic disclosure system) — free key at https://opendart.fss.or.kr/
+DART_API_KEY=
+
 # X (Twitter) API — read-only Bearer Token for the X MCP server.
 # Primary path: users store X_BEARER_TOKEN per-workspace via the UI —
 #   Workspace Files panel → settings icon (top of panel) → Workspace Settings

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -217,6 +217,17 @@ mcp:
       args: ["run", "python", "mcp_servers/korean/kr_price_mcp_server.py"]
       env: {}
 
+    - name: "kr_dart"
+      enabled: true
+      description: "DART electronic disclosure system — K-IFRS financial statements, disclosure lists, company search, major shareholder reports via OpenDartReader"
+      instruction: "Use for Korean company financials (K-IFRS), DART disclosures, company profiles, and major shareholder (5% rule) reports. Accepts company name, stock code (005930), or DART corp_code."
+      tool_exposure_mode: "detailed"
+      transport: "stdio"
+      command: "uv"
+      args: ["run", "python", "mcp_servers/korean/kr_dart_mcp_server.py"]
+      env:
+        DART_API_KEY: "${DART_API_KEY}"
+
   # Tool discovery settings
   tool_discovery_enabled: true
   lazy_load: true # Load tools on-demand

--- a/mcp_servers/korean/kr_dart_mcp_server.py
+++ b/mcp_servers/korean/kr_dart_mcp_server.py
@@ -74,8 +74,8 @@ def _make_response(
         resp["count"] = count
     elif isinstance(data, list):
         resp["count"] = len(data)
-    elif isinstance(data, dict):
-        resp["count"] = len(data)
+    elif isinstance(data, dict) and data:
+        resp["count"] = 1
     resp.update(extra)
     return resp
 

--- a/mcp_servers/korean/kr_dart_mcp_server.py
+++ b/mcp_servers/korean/kr_dart_mcp_server.py
@@ -1,0 +1,317 @@
+"""Korean DART Disclosure MCP Server.
+
+Provides DART (전자공시시스템) data via OpenDartReader — financial statements,
+disclosure lists, company search, and major shareholder reports.
+
+Requires DART_API_KEY environment variable.
+Get a free key at https://opendart.fss.or.kr/
+
+Tools:
+- search_dart_corp: Find corp_code by company name or stock code
+- get_dart_company_info: Company profile from DART
+- get_dart_financials: K-IFRS financial statements (BS, IS, CF)
+- get_dart_financials_all: Full financial statements (all XBRL items)
+- get_dart_disclosures: Disclosure list with type filters
+- get_dart_major_shareholders: Major shareholder reports (5% rule)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import pandas as pd
+from mcp.server.fastmcp import FastMCP
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _get_dart():
+    """Initialize OpenDartReader with API key from environment."""
+    import OpenDartReader
+
+    api_key = os.getenv("DART_API_KEY")
+    if not api_key:
+        msg = (
+            "DART_API_KEY 환경변수가 설정되지 않았습니다. "
+            "https://opendart.fss.or.kr/ 에서 무료 발급 후 .env에 추가하세요."
+        )
+        raise RuntimeError(msg)
+    return OpenDartReader(api_key)
+
+
+def _df_to_records(df: pd.DataFrame) -> list[dict[str, Any]]:
+    """Convert DataFrame to list of dicts with NaN-safe serialization."""
+    if df is None or (isinstance(df, pd.DataFrame) and df.empty):
+        return []
+
+    records = []
+    for _, row in df.iterrows():
+        record = {}
+        for col in df.columns:
+            val = row[col]
+            if pd.isna(val):
+                record[col] = None
+            elif isinstance(val, float):
+                record[col] = round(val, 4)
+            else:
+                record[col] = val
+        records.append(record)
+    return records
+
+
+def _make_response(
+    data_type: str, data: Any, count: int | None = None, **extra: Any,
+) -> dict:
+    resp: dict[str, Any] = {
+        "data_type": data_type,
+        "source": "dart",
+        "data": data,
+    }
+    if count is not None:
+        resp["count"] = count
+    elif isinstance(data, list):
+        resp["count"] = len(data)
+    elif isinstance(data, dict):
+        resp["count"] = len(data)
+    resp.update(extra)
+    return resp
+
+
+def _make_error(msg: str) -> dict:
+    return {"error": msg}
+
+
+# ---------------------------------------------------------------------------
+# MCP server + tools
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP("KoreanDartMCP")
+
+
+@mcp.tool()
+def search_dart_corp(
+    query: str,
+) -> dict:
+    """Search for a Korean company in DART by name or stock code.
+
+    Returns company profile(s) including corp_code (DART unique ID),
+    corp_name, stock_code, and other details.
+
+    Args:
+        query: Company name (e.g. "삼성전자") or 6-digit stock code (e.g. "005930")
+
+    Returns:
+        dict: List of matching companies with corp_code, corp_name, stock_code.
+    """
+    try:
+        dart = _get_dart()
+
+        if query.isdigit() and len(query) == 6:
+            info = dart.company(query)
+            if info:
+                data = [info] if isinstance(info, dict) else _df_to_records(info)
+                return _make_response("dart_company_search", data, query=query)
+            return _make_response("dart_company_search", [], query=query)
+
+        results = dart.company_by_name(query)
+        if results is None:
+            return _make_response("dart_company_search", [], query=query)
+        if isinstance(results, pd.DataFrame):
+            data = _df_to_records(results)
+        elif isinstance(results, list):
+            data = results
+        else:
+            data = [results] if isinstance(results, dict) else []
+
+        return _make_response("dart_company_search", data, query=query)
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 기업 검색 실패 '{query}': {e}")
+
+
+@mcp.tool()
+def get_dart_company_info(
+    corp: str,
+) -> dict:
+    """Get company profile information from DART.
+
+    Args:
+        corp: Company name, stock code (e.g. "005930"), or DART corp_code
+
+    Returns:
+        dict: Company profile with corp_code, corp_name, ceo_nm, corp_cls,
+        adres, hm_url, ir_url, est_dt, etc.
+    """
+    try:
+        dart = _get_dart()
+        info = dart.company(corp)
+
+        if info is None:
+            return _make_response("dart_company_info", {}, corp=corp)
+        if isinstance(info, dict):
+            data = info
+        elif isinstance(info, pd.DataFrame):
+            data = _df_to_records(info)
+        else:
+            data = {}
+
+        return _make_response("dart_company_info", data, corp=corp)
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 기업 정보 조회 실패 '{corp}': {e}")
+
+
+@mcp.tool()
+def get_dart_financials(
+    corp: str,
+    year: int,
+    reprt_code: str = "11011",
+) -> dict:
+    """Get K-IFRS financial statements from DART.
+
+    Returns key items from balance sheet, income statement, and cash flow.
+    Can query single or multiple companies at once.
+
+    Args:
+        corp: Company name, stock code, or corp_code.
+              For multiple companies, comma-separate: "005930, 000660"
+        year: Business year (e.g. 2024)
+        reprt_code: Report type — "11011" (annual), "11013" (Q1),
+                    "11012" (half), "11014" (Q3)
+
+    Returns:
+        dict: Financial statement items with account_nm, thstrm_amount,
+        frmtrm_amount, bfefrmtrm_amount, etc.
+    """
+    try:
+        dart = _get_dart()
+        result = dart.finstate(corp, year, reprt_code=reprt_code)
+
+        if result is None or (isinstance(result, pd.DataFrame) and result.empty):
+            return _make_response(
+                "dart_financials", [], corp=corp, year=year, reprt_code=reprt_code,
+            )
+
+        records = _df_to_records(result)
+        return _make_response(
+            "dart_financials", records, corp=corp, year=year, reprt_code=reprt_code,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 재무제표 조회 실패 '{corp}' {year}: {e}")
+
+
+@mcp.tool()
+def get_dart_financials_all(
+    corp: str,
+    year: int,
+    reprt_code: str = "11011",
+) -> dict:
+    """Get full financial statements from DART (all XBRL items).
+
+    Unlike get_dart_financials which returns key items only, this returns
+    every line item from the XBRL filing — useful for detailed analysis.
+
+    Args:
+        corp: Stock code (e.g. "005930") or corp_code
+        year: Business year (e.g. 2024)
+        reprt_code: Report type — "11011" (annual), "11013" (Q1),
+                    "11012" (half), "11014" (Q3)
+
+    Returns:
+        dict: All financial statement line items.
+    """
+    try:
+        dart = _get_dart()
+        result = dart.finstate_all(corp, year, reprt_code=reprt_code)
+
+        if result is None or (isinstance(result, pd.DataFrame) and result.empty):
+            return _make_response(
+                "dart_financials_all", [], corp=corp, year=year, reprt_code=reprt_code,
+            )
+
+        records = _df_to_records(result)
+        return _make_response(
+            "dart_financials_all", records, corp=corp, year=year, reprt_code=reprt_code,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 전체 재무제표 조회 실패 '{corp}' {year}: {e}")
+
+
+@mcp.tool()
+def get_dart_disclosures(
+    corp: str,
+    start: Optional[str] = None,
+    end: Optional[str] = None,
+    kind: str = "",
+) -> dict:
+    """Get disclosure list from DART for a company.
+
+    Args:
+        corp: Company name, stock code, or corp_code
+        start: Start date — YYYY-MM-DD (default: 1999-01-01)
+        end: End date — YYYY-MM-DD (default: today)
+        kind: Disclosure type filter:
+              "" (all), "A" (정기공시), "B" (주요사항공시),
+              "C" (발행공시), "D" (지분공시), "E" (기타공시)
+
+    Returns:
+        dict: List of disclosures with rcept_no, corp_name, report_nm,
+        rcept_dt, etc.
+    """
+    try:
+        dart = _get_dart()
+
+        kwargs: dict[str, Any] = {}
+        if start:
+            kwargs["start"] = start
+        if end:
+            kwargs["end"] = end
+        if kind:
+            kwargs["kind"] = kind
+
+        result = dart.list(corp, **kwargs)
+
+        if result is None or (isinstance(result, pd.DataFrame) and result.empty):
+            return _make_response(
+                "dart_disclosures", [], corp=corp, kind=kind or "all",
+            )
+
+        records = _df_to_records(result)
+        return _make_response(
+            "dart_disclosures", records, corp=corp, kind=kind or "all",
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 공시 목록 조회 실패 '{corp}': {e}")
+
+
+@mcp.tool()
+def get_dart_major_shareholders(
+    corp: str,
+) -> dict:
+    """Get major shareholder reports (5% rule) from DART.
+
+    Returns large shareholding status reports for a company.
+
+    Args:
+        corp: Company name, stock code (e.g. "005930"), or corp_code
+
+    Returns:
+        dict: Major shareholder reports with shareholder details,
+        share counts, and ownership percentages.
+    """
+    try:
+        dart = _get_dart()
+        result = dart.major_shareholders(corp)
+
+        if result is None or (isinstance(result, pd.DataFrame) and result.empty):
+            return _make_response("dart_major_shareholders", [], corp=corp)
+
+        records = _df_to_records(result)
+        return _make_response("dart_major_shareholders", records, corp=corp)
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"DART 대량보유 조회 실패 '{corp}': {e}")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,6 +73,7 @@ dependencies = [
     "croniter>=2.0.0",
     "aiodocker>=0.23.0",
     "pykrx>=1.0.45",  # FORK: 한국 시장 데이터 (KOSPI/KOSDAQ)
+    "opendartreader>=0.2.2",  # FORK: DART 전자공시
 ]
 
 [tool.uv.sources]

--- a/tests/unit/mcp_servers/korean/test_kr_dart_mcp.py
+++ b/tests/unit/mcp_servers/korean/test_kr_dart_mcp.py
@@ -1,0 +1,305 @@
+"""Tests for kr_dart_mcp_server tools.
+
+Tests all tools using mocked OpenDartReader responses.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import pandas as pd
+import pytest
+
+from mcp_servers.korean.kr_dart_mcp_server import (
+    get_dart_company_info,
+    get_dart_disclosures,
+    get_dart_financials,
+    get_dart_financials_all,
+    get_dart_major_shareholders,
+    search_dart_corp,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture
+def mock_dart():
+    """Mock OpenDartReader instance."""
+    with patch("mcp_servers.korean.kr_dart_mcp_server._get_dart") as mock_get:
+        dart = MagicMock()
+        mock_get.return_value = dart
+        yield dart
+
+
+@pytest.fixture
+def mock_company_info():
+    return {
+        "corp_code": "00126380",
+        "corp_name": "삼성전자",
+        "stock_code": "005930",
+        "ceo_nm": "한종희",
+        "corp_cls": "Y",
+        "adres": "경기도 수원시 영통구 삼성로 129",
+    }
+
+
+@pytest.fixture
+def mock_finstate_df():
+    return pd.DataFrame({
+        "rcept_no": ["20240401000001", "20240401000001"],
+        "bsns_year": ["2023", "2023"],
+        "corp_code": ["00126380", "00126380"],
+        "account_nm": ["매출액", "영업이익"],
+        "thstrm_amount": ["258935000000000", "36183000000000"],
+        "frmtrm_amount": ["302231000000000", "43376000000000"],
+    })
+
+
+@pytest.fixture
+def mock_disclosure_df():
+    return pd.DataFrame({
+        "corp_name": ["삼성전자", "삼성전자"],
+        "report_nm": ["사업보고서 (2023.12)", "[기재정정]주요사항보고서"],
+        "rcept_no": ["20240401000001", "20240315000002"],
+        "rcept_dt": ["2024-04-01", "2024-03-15"],
+        "flr_nm": ["삼성전자", "삼성전자"],
+    })
+
+
+@pytest.fixture
+def mock_shareholders_df():
+    return pd.DataFrame({
+        "rcept_no": ["20240301000001"],
+        "corp_name": ["삼성전자"],
+        "report_tp": ["대량보유상황보고"],
+        "repror": ["국민연금공단"],
+        "stkqy": ["500000000"],
+        "stkrt": ["8.37"],
+    })
+
+
+# ============================================================================
+# search_dart_corp
+# ============================================================================
+
+
+class TestSearchDartCorp:
+    def test_search_by_name(self, mock_dart):
+        mock_dart.company_by_name.return_value = pd.DataFrame({
+            "corp_code": ["00126380", "00164779"],
+            "corp_name": ["삼성전자", "삼성전자우"],
+            "stock_code": ["005930", "005935"],
+        })
+
+        result = search_dart_corp("삼성전자")
+
+        assert result["data_type"] == "dart_company_search"
+        assert result["count"] == 2
+        assert result["data"][0]["corp_name"] == "삼성전자"
+        mock_dart.company_by_name.assert_called_once_with("삼성전자")
+
+    def test_search_by_stock_code(self, mock_dart, mock_company_info):
+        mock_dart.company.return_value = mock_company_info
+
+        result = search_dart_corp("005930")
+
+        assert result["count"] == 1
+        assert result["data"][0]["corp_name"] == "삼성전자"
+        mock_dart.company.assert_called_once_with("005930")
+
+    def test_no_results(self, mock_dart):
+        mock_dart.company_by_name.return_value = None
+
+        result = search_dart_corp("존재하지않는기업")
+
+        assert result["data"] == []
+        assert result["count"] == 0
+
+    def test_exception(self, mock_dart):
+        mock_dart.company_by_name.side_effect = RuntimeError("API error")
+
+        result = search_dart_corp("삼성전자")
+
+        assert "error" in result
+
+
+# ============================================================================
+# get_dart_company_info
+# ============================================================================
+
+
+class TestGetDartCompanyInfo:
+    def test_success(self, mock_dart, mock_company_info):
+        mock_dart.company.return_value = mock_company_info
+
+        result = get_dart_company_info("005930")
+
+        assert result["data_type"] == "dart_company_info"
+        assert result["data"]["corp_name"] == "삼성전자"
+
+    def test_not_found(self, mock_dart):
+        mock_dart.company.return_value = None
+
+        result = get_dart_company_info("999999")
+
+        assert result["data"] == {}
+
+    def test_exception(self, mock_dart):
+        mock_dart.company.side_effect = RuntimeError("fail")
+
+        result = get_dart_company_info("005930")
+
+        assert "error" in result
+
+
+# ============================================================================
+# get_dart_financials
+# ============================================================================
+
+
+class TestGetDartFinancials:
+    def test_success(self, mock_dart, mock_finstate_df):
+        mock_dart.finstate.return_value = mock_finstate_df
+
+        result = get_dart_financials("삼성전자", 2023)
+
+        assert result["data_type"] == "dart_financials"
+        assert result["count"] == 2
+        assert result["year"] == 2023
+        assert result["reprt_code"] == "11011"
+        assert result["data"][0]["account_nm"] == "매출액"
+
+    def test_quarterly(self, mock_dart, mock_finstate_df):
+        mock_dart.finstate.return_value = mock_finstate_df
+
+        get_dart_financials("005930", 2023, reprt_code="11013")
+
+        mock_dart.finstate.assert_called_once_with("005930", 2023, reprt_code="11013")
+
+    def test_empty(self, mock_dart):
+        mock_dart.finstate.return_value = pd.DataFrame()
+
+        result = get_dart_financials("005930", 2023)
+
+        assert result["data"] == []
+        assert result["count"] == 0
+
+    def test_multiple_corps(self, mock_dart, mock_finstate_df):
+        mock_dart.finstate.return_value = mock_finstate_df
+
+        get_dart_financials("005930, 000660", 2023)
+
+        mock_dart.finstate.assert_called_once_with("005930, 000660", 2023, reprt_code="11011")
+
+    def test_exception(self, mock_dart):
+        mock_dart.finstate.side_effect = RuntimeError("API limit")
+
+        result = get_dart_financials("005930", 2023)
+
+        assert "error" in result
+
+
+# ============================================================================
+# get_dart_financials_all
+# ============================================================================
+
+
+class TestGetDartFinancialsAll:
+    def test_success(self, mock_dart, mock_finstate_df):
+        mock_dart.finstate_all.return_value = mock_finstate_df
+
+        result = get_dart_financials_all("005930", 2023)
+
+        assert result["data_type"] == "dart_financials_all"
+        assert result["count"] == 2
+
+    def test_empty(self, mock_dart):
+        mock_dart.finstate_all.return_value = None
+
+        result = get_dart_financials_all("005930", 2023)
+
+        assert result["data"] == []
+
+    def test_exception(self, mock_dart):
+        mock_dart.finstate_all.side_effect = RuntimeError("fail")
+
+        result = get_dart_financials_all("005930", 2023)
+
+        assert "error" in result
+
+
+# ============================================================================
+# get_dart_disclosures
+# ============================================================================
+
+
+class TestGetDartDisclosures:
+    def test_all_disclosures(self, mock_dart, mock_disclosure_df):
+        mock_dart.list.return_value = mock_disclosure_df
+
+        result = get_dart_disclosures("005930")
+
+        assert result["data_type"] == "dart_disclosures"
+        assert result["count"] == 2
+        assert result["kind"] == "all"
+
+    def test_filtered_by_kind(self, mock_dart, mock_disclosure_df):
+        mock_dart.list.return_value = mock_disclosure_df
+
+        get_dart_disclosures("005930", kind="A")
+
+        mock_dart.list.assert_called_once_with("005930", kind="A")
+
+    def test_with_date_range(self, mock_dart, mock_disclosure_df):
+        mock_dart.list.return_value = mock_disclosure_df
+
+        get_dart_disclosures("삼성전자", start="2024-01-01", end="2024-12-31", kind="B")
+
+        mock_dart.list.assert_called_once_with(
+            "삼성전자", start="2024-01-01", end="2024-12-31", kind="B",
+        )
+
+    def test_empty(self, mock_dart):
+        mock_dart.list.return_value = pd.DataFrame()
+
+        result = get_dart_disclosures("999999")
+
+        assert result["data"] == []
+
+    def test_exception(self, mock_dart):
+        mock_dart.list.side_effect = RuntimeError("fail")
+
+        result = get_dart_disclosures("005930")
+
+        assert "error" in result
+
+
+# ============================================================================
+# get_dart_major_shareholders
+# ============================================================================
+
+
+class TestGetDartMajorShareholders:
+    def test_success(self, mock_dart, mock_shareholders_df):
+        mock_dart.major_shareholders.return_value = mock_shareholders_df
+
+        result = get_dart_major_shareholders("삼성전자")
+
+        assert result["data_type"] == "dart_major_shareholders"
+        assert result["count"] == 1
+        assert result["data"][0]["repror"] == "국민연금공단"
+
+    def test_empty(self, mock_dart):
+        mock_dart.major_shareholders.return_value = pd.DataFrame()
+
+        result = get_dart_major_shareholders("005930")
+
+        assert result["data"] == []
+
+    def test_exception(self, mock_dart):
+        mock_dart.major_shareholders.side_effect = RuntimeError("fail")
+
+        result = get_dart_major_shareholders("005930")
+
+        assert "error" in result

--- a/tests/unit/mcp_servers/korean/test_kr_dart_mcp.py
+++ b/tests/unit/mcp_servers/korean/test_kr_dart_mcp.py
@@ -5,10 +5,12 @@ Tests all tools using mocked OpenDartReader responses.
 
 from unittest.mock import MagicMock, patch
 
+import numpy as np
 import pandas as pd
 import pytest
 
 from mcp_servers.korean.kr_dart_mcp_server import (
+    _df_to_records,
     get_dart_company_info,
     get_dart_disclosures,
     get_dart_financials,
@@ -16,6 +18,34 @@ from mcp_servers.korean.kr_dart_mcp_server import (
     get_dart_major_shareholders,
     search_dart_corp,
 )
+
+
+# ============================================================================
+# _df_to_records
+# ============================================================================
+
+
+class TestDfToRecords:
+    def test_nan_converted_to_none(self):
+        df = pd.DataFrame({
+            "name": ["삼성전자", "SK하이닉스"],
+            "value": [100.5, np.nan],
+            "count": [10, np.nan],
+        })
+
+        records = _df_to_records(df)
+
+        assert len(records) == 2
+        assert records[0]["name"] == "삼성전자"
+        assert records[0]["value"] == 100.5
+        assert records[1]["value"] is None
+        assert records[1]["count"] is None
+
+    def test_empty_dataframe(self):
+        assert _df_to_records(pd.DataFrame()) == []
+
+    def test_none_input(self):
+        assert _df_to_records(None) == []
 
 
 # ============================================================================

--- a/uv.lock
+++ b/uv.lock
@@ -2726,6 +2726,21 @@ wheels = [
 ]
 
 [[package]]
+name = "opendartreader"
+version = "0.2.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "beautifulsoup4" },
+    { name = "lxml" },
+    { name = "pandas" },
+    { name = "requests" },
+    { name = "requests-file" },
+]
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d9/23/e76575618af74b3572b6791b6e1cc403832af9cb2d6c6961a0749b37bf84/OpenDartReader-0.2.3-py3-none-any.whl", hash = "sha256:710c01969e5b01dc1b7bc78a9f5f13cad11623cdb2f6ed45110f6cd40a111ecc", size = 27544, upload-time = "2023-03-15T07:17:25.548Z" },
+]
+
+[[package]]
 name = "opentelemetry-api"
 version = "1.41.0"
 source = { registry = "https://pypi.org/simple" }
@@ -3422,6 +3437,7 @@ dependencies = [
     { name = "mcp" },
     { name = "mplfinance" },
     { name = "numpy" },
+    { name = "opendartreader" },
     { name = "pandas" },
     { name = "pdfplumber" },
     { name = "playwright" },
@@ -3502,6 +3518,7 @@ requires-dist = [
     { name = "mcp", specifier = ">=1.6.0" },
     { name = "mplfinance", specifier = "==0.12.10b0" },
     { name = "numpy", specifier = ">=1.24,<3.0" },
+    { name = "opendartreader", specifier = ">=0.2.2" },
     { name = "pandas", specifier = ">=2.2.3" },
     { name = "pdfplumber", specifier = ">=0.10.0" },
     { name = "playwright" },
@@ -4276,6 +4293,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+]
+
+[[package]]
+name = "requests-file"
+version = "3.0.1"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "requests" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/3c/f8/5dc70102e4d337063452c82e1f0d95e39abfe67aa222ed8a5ddeb9df8de8/requests_file-3.0.1.tar.gz", hash = "sha256:f14243d7796c588f3521bd423c5dea2ee4cc730e54a3cac9574d78aca1272576", size = 6967, upload-time = "2025-10-20T18:56:42.279Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e1/d5/de8f089119205a09da657ed4784c584ede8381a0ce6821212a6d4ca47054/requests_file-3.0.1-py2.py3-none-any.whl", hash = "sha256:d0f5eb94353986d998f80ac63c7f146a307728be051d4d1cd390dbdb59c10fa2", size = 4514, upload-time = "2025-10-20T18:56:41.184Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## 요약
Closes #6
DART 전자공시 데이터를 PTC 에이전트에서 조회할 수 있도록 kr_dart MCP 서버를 추가한다.

## 변경 사항
- `mcp_servers/korean/kr_dart_mcp_server.py`: FastMCP 서버 6개 도구 (기업검색, 기업정보, 주요재무제표, 전체재무제표, 공시목록, 대량보유)
- `tests/unit/mcp_servers/korean/test_kr_dart_mcp.py`: 23개 단위 테스트 (mock 기반)
- `pyproject.toml`: `opendartreader>=0.2.2` 의존성 추가
- `agent_config.yaml`: `kr_dart` MCP 서버 등록 (DART_API_KEY 환경변수 전달)
- `.env.example`: `DART_API_KEY` 항목 추가

## 기술적 판단
- **_get_dart() 팩토리 패턴**: OpenDartReader는 인스턴스 생성 시 API 키가 필요. 도구 호출마다 환경변수에서 읽어 초기화. 키 없으면 명확한 에러 메시지 반환.
- **corp 파라미터 통일**: OpenDartReader가 종목코드/기업명/corp_code 모두 허용하므로 도구 파라미터를 `corp`으로 통일하여 사용자 편의 극대화.
- **DataFrame → dict 직렬화**: NaN-safe `_df_to_records()` 헬퍼로 통일. NaN → None.
- **reprt_code 기본값 11011**: 사업보고서(연간)를 기본으로, 분기별 조회는 파라미터로 지정.

## 검증
- `uv run pytest tests/unit/mcp_servers/korean/test_kr_dart_mcp.py -v` → 23개 전체 통과
- `uv run pytest tests/unit/ -v` → 2895개 전체 통과 (리그레션 없음)
- `ruff check` → All checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **신규 기능**
  * 한국 전자공시 시스템 통합으로 상장사의 공시 정보 및 재무 데이터 조회 기능 추가
  * 기업 검색, 기업 정보, K-IFRS 재무제표, 공시 내역, 대주주 현황 조회 지원
  * 공시 조회 시 기간 및 공시 유형별 필터링 기능 포함

* **테스트**
  * 신규 조회 기능에 대한 단위 테스트 추가

* **기타**
  * 시스템 통합을 위한 환경 설정 및 필수 라이브러리 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->