### PR TITLE
feat: ECOS 기반 한국 매크로 경제 MCP 서버 구현

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -56,6 +56,9 @@ ALPHA_VANTAGE_API_KEY=
 # FORK: DART (Korean electronic disclosure system) — free key at https://opendart.fss.or.kr/
 DART_API_KEY=
 
+# FORK: ECOS (Bank of Korea economic statistics) — free key at https://ecos.bok.or.kr/api/
+ECOS_API_KEY=
+
 # X (Twitter) API — read-only Bearer Token for the X MCP server.
 # Primary path: users store X_BEARER_TOKEN per-workspace via the UI —
 #   Workspace Files panel → settings icon (top of panel) → Workspace Settings

--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -228,6 +228,17 @@ mcp:
       env:
         DART_API_KEY: "${DART_API_KEY}"
 
+    - name: "kr_ecos"
+      enabled: true
+      description: "Korean macroeconomic data from Bank of Korea ECOS — base rate, GDP, CPI, exchange rates, treasury yields"
+      instruction: "Use for Korean macro data: BOK base rate (for WACC), GDP growth, CPI, unemployment, KRW exchange rates, and government bond yields. Essential for Korean DCF models."
+      tool_exposure_mode: "detailed"
+      transport: "stdio"
+      command: "uv"
+      args: ["run", "python", "mcp_servers/korean/kr_ecos_mcp_server.py"]
+      env:
+        ECOS_API_KEY: "${ECOS_API_KEY}"
+
   # Tool discovery settings
   tool_discovery_enabled: true
   lazy_load: true # Load tools on-demand

--- a/mcp_servers/korean/kr_ecos_mcp_server.py
+++ b/mcp_servers/korean/kr_ecos_mcp_server.py
@@ -77,6 +77,15 @@ def _get_api_key() -> str:
     return api_key
 
 
+def _sanitize_error(error: Exception) -> str:
+    """Remove API key from error messages to prevent leakage."""
+    msg = str(error)
+    api_key = os.getenv("ECOS_API_KEY", "")
+    if api_key and api_key in msg:
+        msg = msg.replace(api_key, "***")
+    return msg
+
+
 def _fetch_ecos(
     stat_code: str,
     item_code: str,
@@ -97,10 +106,13 @@ def _fetch_ecos(
         f"/{stat_code}/{cycle}/{start}/{end}/{item_code}"
     )
 
-    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
-        resp = client.get(url)
-        resp.raise_for_status()
-        data = resp.json()
+    try:
+        with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+            resp = client.get(url)
+            resp.raise_for_status()
+            data = resp.json()
+    except (httpx.HTTPStatusError, httpx.RequestError) as exc:
+        raise RuntimeError(_sanitize_error(exc)) from exc
 
     if "RESULT" in data:
         code = data["RESULT"].get("CODE", "")
@@ -155,6 +167,13 @@ def _make_error(msg: str) -> dict:
     return {"error": msg}
 
 
+def _require_dates(from_date: str, to_date: str) -> str | None:
+    """Return error message if dates are missing, else None."""
+    if not from_date or not to_date:
+        return "from_date와 to_date는 필수입니다."
+    return None
+
+
 # ---------------------------------------------------------------------------
 # MCP server + tools
 # ---------------------------------------------------------------------------
@@ -187,7 +206,7 @@ def get_kr_base_rate(
             "kr_base_rate", records, from_date=from_date, to_date=to_date,
         )
     except Exception as e:  # noqa: BLE001
-        return _make_error(f"한은 기준금리 조회 실패: {e}")
+        return _make_error(f"한은 기준금리 조회 실패: {_sanitize_error(e)}")
 
 
 @mcp.tool()
@@ -235,7 +254,7 @@ def get_kr_economic_indicator(
             indicator=indicator, from_date=from_date, to_date=to_date,
         )
     except Exception as e:  # noqa: BLE001
-        return _make_error(f"경제지표 조회 실패 '{indicator}': {e}")
+        return _make_error(f"경제지표 조회 실패 '{indicator}': {_sanitize_error(e)}")
 
 
 @mcp.tool()
@@ -250,14 +269,18 @@ def get_kr_exchange_rate(
     Args:
         currency: Target currency — "USD", "JPY" (100엔), "EUR", "GBP",
                   "CAD", "CHF", "AUD", "CNY"
-        from_date: Start date — YYYYMMDD or YYYY-MM-DD
-        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD (required)
+        to_date: End date — YYYYMMDD or YYYY-MM-DD (required)
         cycle: Frequency — "D" (daily), "M" (monthly), "A" (annual)
 
     Returns:
         dict: Exchange rate time series (KRW per unit of foreign currency).
     """
     try:
+        date_err = _require_dates(from_date, to_date)
+        if date_err:
+            return _make_error(date_err)
+
         item_code = _EXCHANGE_RATE_CODES.get(currency.upper())
         if not item_code:
             available = ", ".join(sorted(_EXCHANGE_RATE_CODES.keys()))
@@ -272,7 +295,7 @@ def get_kr_exchange_rate(
             currency=currency.upper(), from_date=from_date, to_date=to_date,
         )
     except Exception as e:  # noqa: BLE001
-        return _make_error(f"환율 조회 실패 '{currency}': {e}")
+        return _make_error(f"환율 조회 실패 '{currency}': {_sanitize_error(e)}")
 
 
 @mcp.tool()
@@ -289,14 +312,18 @@ def get_kr_treasury_yield(
     Args:
         maturity: Bond maturity — "1Y", "2Y", "3Y", "5Y", "10Y",
                   "20Y", "30Y", "50Y"
-        from_date: Start date — YYYYMMDD or YYYY-MM-DD
-        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD (required)
+        to_date: End date — YYYYMMDD or YYYY-MM-DD (required)
         cycle: Frequency — "D" (daily), "M" (monthly), "A" (annual)
 
     Returns:
         dict: Treasury yield time series (%).
     """
     try:
+        date_err = _require_dates(from_date, to_date)
+        if date_err:
+            return _make_error(date_err)
+
         item_code = _TREASURY_CODES.get(maturity.upper())
         if not item_code:
             available = ", ".join(sorted(_TREASURY_CODES.keys()))
@@ -311,7 +338,7 @@ def get_kr_treasury_yield(
             maturity=maturity.upper(), from_date=from_date, to_date=to_date,
         )
     except Exception as e:  # noqa: BLE001
-        return _make_error(f"국고채 수익률 조회 실패 '{maturity}': {e}")
+        return _make_error(f"국고채 수익률 조회 실패 '{maturity}': {_sanitize_error(e)}")
 
 
 if __name__ == "__main__":

--- a/mcp_servers/korean/kr_ecos_mcp_server.py
+++ b/mcp_servers/korean/kr_ecos_mcp_server.py
@@ -1,0 +1,318 @@
+"""Korean ECOS Macro MCP Server.
+
+Provides Korean macroeconomic data via the Bank of Korea ECOS API —
+base rate, GDP, CPI, exchange rates, and treasury yields.
+
+Requires ECOS_API_KEY environment variable.
+Get a free key at https://ecos.bok.or.kr/api/
+
+Tools:
+- get_kr_base_rate: Bank of Korea base interest rate
+- get_kr_economic_indicator: GDP, CPI, unemployment, and other indicators
+- get_kr_exchange_rate: KRW exchange rates (USD, JPY, EUR, etc.)
+- get_kr_treasury_yield: Korean government bond yields (3Y, 5Y, 10Y, etc.)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import Any, Optional
+
+import httpx
+from mcp.server.fastmcp import FastMCP
+
+
+# ---------------------------------------------------------------------------
+# ECOS API client
+# ---------------------------------------------------------------------------
+
+_ECOS_BASE = "https://ecos.bok.or.kr/api/StatisticSearch"
+_HTTP_TIMEOUT = 30.0
+
+# Indicator presets: name -> (stat_code, item_code, cycle)
+_INDICATOR_PRESETS: dict[str, tuple[str, str, str]] = {
+    "gdp_growth": ("200Y002", "10111", "Q"),
+    "cpi": ("021Y125", "0", "M"),
+    "unemployment": ("901Y027", "3130000", "M"),
+    "export": ("403Y003", "10000", "M"),
+    "import": ("403Y003", "20000", "M"),
+    "industrial_production": ("901Y033", "I11B", "M"),
+    "consumer_sentiment": ("511Y002", "FME", "M"),
+    "money_supply_m2": ("101Y003", "BBGA00", "M"),
+}
+
+# Exchange rate item codes (under stat_code 731Y001)
+_EXCHANGE_RATE_CODES: dict[str, str] = {
+    "USD": "0000001",
+    "JPY": "0000002",
+    "EUR": "0000003",
+    "GBP": "0000004",
+    "CAD": "0000009",
+    "CHF": "0000006",
+    "AUD": "0000013",
+    "CNY": "0000053",
+}
+
+# Treasury yield item codes (under stat_code 817Y002)
+_TREASURY_CODES: dict[str, str] = {
+    "1Y": "010190000",
+    "2Y": "010195000",
+    "3Y": "010200000",
+    "5Y": "010200001",
+    "10Y": "010210000",
+    "20Y": "010220000",
+    "30Y": "010230000",
+    "50Y": "010240000",
+}
+
+
+def _get_api_key() -> str:
+    api_key = os.getenv("ECOS_API_KEY")
+    if not api_key:
+        msg = (
+            "ECOS_API_KEY 환경변수가 설정되지 않았습니다. "
+            "https://ecos.bok.or.kr/api/ 에서 무료 발급 후 .env에 추가하세요."
+        )
+        raise RuntimeError(msg)
+    return api_key
+
+
+def _fetch_ecos(
+    stat_code: str,
+    item_code: str,
+    cycle: str,
+    start_date: str,
+    end_date: str,
+    start_idx: int = 1,
+    end_idx: int = 500,
+) -> list[dict[str, Any]]:
+    """Call ECOS StatisticSearch API and return row data."""
+    api_key = _get_api_key()
+    start = start_date.replace("-", "")
+    end = end_date.replace("-", "")
+
+    url = (
+        f"{_ECOS_BASE}/{api_key}/json/kr"
+        f"/{start_idx}/{end_idx}"
+        f"/{stat_code}/{cycle}/{start}/{end}/{item_code}"
+    )
+
+    with httpx.Client(timeout=_HTTP_TIMEOUT) as client:
+        resp = client.get(url)
+        resp.raise_for_status()
+        data = resp.json()
+
+    if "RESULT" in data:
+        code = data["RESULT"].get("CODE", "")
+        message = data["RESULT"].get("MESSAGE", "Unknown error")
+        if code.startswith("ERROR"):
+            msg = f"ECOS API 오류 ({code}): {message}"
+            raise RuntimeError(msg)
+
+    stat = data.get("StatisticSearch")
+    if not stat or "row" not in stat:
+        return []
+
+    return stat["row"]
+
+
+def _format_rows(rows: list[dict[str, Any]]) -> list[dict[str, Any]]:
+    """Normalize ECOS row data to a consistent format."""
+    records = []
+    for row in rows:
+        record: dict[str, Any] = {
+            "date": row.get("TIME", ""),
+            "value": row.get("DATA_VALUE", ""),
+            "stat_name": row.get("STAT_NAME", ""),
+            "item_name": row.get("ITEM_NAME1", ""),
+            "unit": row.get("UNIT_NAME", ""),
+        }
+        try:
+            record["value"] = float(record["value"])
+        except (ValueError, TypeError):
+            pass
+        records.append(record)
+    return records
+
+
+def _make_response(
+    data_type: str, data: Any, count: int | None = None, **extra: Any,
+) -> dict:
+    resp: dict[str, Any] = {
+        "data_type": data_type,
+        "source": "ecos",
+        "data": data,
+    }
+    if count is not None:
+        resp["count"] = count
+    elif isinstance(data, list):
+        resp["count"] = len(data)
+    resp.update(extra)
+    return resp
+
+
+def _make_error(msg: str) -> dict:
+    return {"error": msg}
+
+
+# ---------------------------------------------------------------------------
+# MCP server + tools
+# ---------------------------------------------------------------------------
+
+mcp = FastMCP("KoreanEcosMCP")
+
+
+@mcp.tool()
+def get_kr_base_rate(
+    from_date: str,
+    to_date: str,
+    cycle: str = "M",
+) -> dict:
+    """Get Bank of Korea base interest rate (한은 기준금리).
+
+    Essential for WACC calculation in Korean DCF models.
+
+    Args:
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD
+        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        cycle: Data frequency — "D" (daily), "M" (monthly), "A" (annual)
+
+    Returns:
+        dict: Time series of base rate values with date, value, unit.
+    """
+    try:
+        rows = _fetch_ecos("722Y001", "0101000", cycle, from_date, to_date)
+        records = _format_rows(rows)
+        return _make_response(
+            "kr_base_rate", records, from_date=from_date, to_date=to_date,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"한은 기준금리 조회 실패: {e}")
+
+
+@mcp.tool()
+def get_kr_economic_indicator(
+    indicator: str,
+    from_date: str,
+    to_date: str,
+    cycle: Optional[str] = None,
+) -> dict:
+    """Get Korean economic indicator time series from ECOS.
+
+    Args:
+        indicator: Indicator name — one of:
+            "gdp_growth" (GDP 성장률, quarterly),
+            "cpi" (소비자물가지수, monthly),
+            "unemployment" (실업률, monthly),
+            "export" (수출, monthly),
+            "import" (수입, monthly),
+            "industrial_production" (산업생산지수, monthly),
+            "consumer_sentiment" (소비자심리지수, monthly),
+            "money_supply_m2" (M2 통화량, monthly)
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD
+        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        cycle: Override frequency — "M" (monthly), "Q" (quarterly), "A" (annual).
+               If not set, uses the indicator's default.
+
+    Returns:
+        dict: Time series with date, value, stat_name, item_name, unit.
+    """
+    try:
+        preset = _INDICATOR_PRESETS.get(indicator)
+        if not preset:
+            available = ", ".join(sorted(_INDICATOR_PRESETS.keys()))
+            return _make_error(
+                f"알 수 없는 지표 '{indicator}'. 사용 가능: {available}"
+            )
+
+        stat_code, item_code, default_cycle = preset
+        use_cycle = cycle or default_cycle
+
+        rows = _fetch_ecos(stat_code, item_code, use_cycle, from_date, to_date)
+        records = _format_rows(rows)
+        return _make_response(
+            "kr_economic_indicator", records,
+            indicator=indicator, from_date=from_date, to_date=to_date,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"경제지표 조회 실패 '{indicator}': {e}")
+
+
+@mcp.tool()
+def get_kr_exchange_rate(
+    currency: str = "USD",
+    from_date: str = "",
+    to_date: str = "",
+    cycle: str = "M",
+) -> dict:
+    """Get KRW exchange rate (원화 환율).
+
+    Args:
+        currency: Target currency — "USD", "JPY" (100엔), "EUR", "GBP",
+                  "CAD", "CHF", "AUD", "CNY"
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD
+        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        cycle: Frequency — "D" (daily), "M" (monthly), "A" (annual)
+
+    Returns:
+        dict: Exchange rate time series (KRW per unit of foreign currency).
+    """
+    try:
+        item_code = _EXCHANGE_RATE_CODES.get(currency.upper())
+        if not item_code:
+            available = ", ".join(sorted(_EXCHANGE_RATE_CODES.keys()))
+            return _make_error(
+                f"알 수 없는 통화 '{currency}'. 사용 가능: {available}"
+            )
+
+        rows = _fetch_ecos("731Y001", item_code, cycle, from_date, to_date)
+        records = _format_rows(rows)
+        return _make_response(
+            "kr_exchange_rate", records,
+            currency=currency.upper(), from_date=from_date, to_date=to_date,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"환율 조회 실패 '{currency}': {e}")
+
+
+@mcp.tool()
+def get_kr_treasury_yield(
+    maturity: str = "10Y",
+    from_date: str = "",
+    to_date: str = "",
+    cycle: str = "M",
+) -> dict:
+    """Get Korean government bond yield (국고채 수익률).
+
+    Essential for risk-free rate in Korean CAPM/DCF models.
+
+    Args:
+        maturity: Bond maturity — "1Y", "2Y", "3Y", "5Y", "10Y",
+                  "20Y", "30Y", "50Y"
+        from_date: Start date — YYYYMMDD or YYYY-MM-DD
+        to_date: End date — YYYYMMDD or YYYY-MM-DD
+        cycle: Frequency — "D" (daily), "M" (monthly), "A" (annual)
+
+    Returns:
+        dict: Treasury yield time series (%).
+    """
+    try:
+        item_code = _TREASURY_CODES.get(maturity.upper())
+        if not item_code:
+            available = ", ".join(sorted(_TREASURY_CODES.keys()))
+            return _make_error(
+                f"알 수 없는 만기 '{maturity}'. 사용 가능: {available}"
+            )
+
+        rows = _fetch_ecos("817Y002", item_code, cycle, from_date, to_date)
+        records = _format_rows(rows)
+        return _make_response(
+            "kr_treasury_yield", records,
+            maturity=maturity.upper(), from_date=from_date, to_date=to_date,
+        )
+    except Exception as e:  # noqa: BLE001
+        return _make_error(f"국고채 수익률 조회 실패 '{maturity}': {e}")
+
+
+if __name__ == "__main__":
+    mcp.run(transport="stdio")

--- a/tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py
+++ b/tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py
@@ -239,3 +239,57 @@ class TestGetKrTreasuryYield:
         result = get_kr_treasury_yield("10Y", "2024-01-01", "2024-12-31")
 
         assert "error" in result
+
+    def test_empty_dates(self):
+        result = get_kr_treasury_yield("10Y", from_date="", to_date="")
+
+        assert "error" in result
+        assert "필수" in result["error"]
+
+
+# ============================================================================
+# Empty date validation
+# ============================================================================
+
+
+class TestEmptyDateValidation:
+    def test_exchange_rate_empty_dates(self):
+        result = get_kr_exchange_rate("USD")
+
+        assert "error" in result
+        assert "필수" in result["error"]
+
+    def test_exchange_rate_missing_to_date(self):
+        result = get_kr_exchange_rate("USD", from_date="2024-01-01")
+
+        assert "error" in result
+
+    def test_treasury_empty_dates(self):
+        result = get_kr_treasury_yield("10Y")
+
+        assert "error" in result
+        assert "필수" in result["error"]
+
+
+# ============================================================================
+# API key masking
+# ============================================================================
+
+
+class TestApiKeyMasking:
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_key_not_in_error_message(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        # Simulate error containing the API key in the URL
+        mock_client.get.side_effect = httpx.HTTPError(
+            "GET https://ecos.bok.or.kr/api/StatisticSearch/test-key/json/kr/... failed"
+        )
+        mock_client_cls.return_value = mock_client
+
+        result = get_kr_base_rate("2024-01-01", "2024-12-31")
+
+        assert "error" in result
+        assert "test-key" not in result["error"]
+        assert "***" in result["error"]

--- a/tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py
+++ b/tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py
@@ -1,0 +1,241 @@
+"""Tests for kr_ecos_mcp_server tools.
+
+Tests all tools using mocked ECOS API (httpx) responses.
+"""
+
+from unittest.mock import MagicMock, patch
+
+import httpx
+import pytest
+
+from mcp_servers.korean.kr_ecos_mcp_server import (
+    get_kr_base_rate,
+    get_kr_economic_indicator,
+    get_kr_exchange_rate,
+    get_kr_treasury_yield,
+)
+
+
+# ============================================================================
+# Fixtures
+# ============================================================================
+
+
+@pytest.fixture(autouse=True)
+def _mock_api_key():
+    """Set ECOS_API_KEY for all tests."""
+    with patch.dict("os.environ", {"ECOS_API_KEY": "test-key"}):
+        yield
+
+
+@pytest.fixture
+def mock_ecos_response():
+    """Standard ECOS API success response."""
+    return {
+        "StatisticSearch": {
+            "list_total_count": 2,
+            "row": [
+                {
+                    "TIME": "202401",
+                    "DATA_VALUE": "3.50",
+                    "STAT_NAME": "한국은행 기준금리",
+                    "ITEM_NAME1": "기준금리",
+                    "UNIT_NAME": "% p.a.",
+                },
+                {
+                    "TIME": "202402",
+                    "DATA_VALUE": "3.50",
+                    "STAT_NAME": "한국은행 기준금리",
+                    "ITEM_NAME1": "기준금리",
+                    "UNIT_NAME": "% p.a.",
+                },
+            ],
+        }
+    }
+
+
+@pytest.fixture
+def mock_ecos_empty():
+    """ECOS API response with no data."""
+    return {"StatisticSearch": {"list_total_count": 0}}
+
+
+@pytest.fixture
+def mock_ecos_error():
+    """ECOS API error response."""
+    return {
+        "RESULT": {
+            "CODE": "ERROR-001",
+            "MESSAGE": "인증키가 유효하지 않습니다.",
+        }
+    }
+
+
+def _mock_httpx_get(response_data):
+    """Create a mock httpx client that returns given response."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = response_data
+    mock_response.raise_for_status = MagicMock()
+
+    mock_client = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    mock_client.get.return_value = mock_response
+    return mock_client
+
+
+# ============================================================================
+# get_kr_base_rate
+# ============================================================================
+
+
+class TestGetKrBaseRate:
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_success(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_base_rate("2024-01-01", "2024-02-28")
+
+        assert result["data_type"] == "kr_base_rate"
+        assert result["source"] == "ecos"
+        assert result["count"] == 2
+        assert result["data"][0]["date"] == "202401"
+        assert result["data"][0]["value"] == 3.50
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_empty(self, mock_client_cls, mock_ecos_empty):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_empty)
+
+        result = get_kr_base_rate("2024-01-01", "2024-01-01")
+
+        assert result["data"] == []
+        assert result["count"] == 0
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_api_error(self, mock_client_cls, mock_ecos_error):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_error)
+
+        result = get_kr_base_rate("2024-01-01", "2024-02-28")
+
+        assert "error" in result
+
+    def test_missing_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            result = get_kr_base_rate("2024-01-01", "2024-02-28")
+
+            assert "error" in result
+            assert "ECOS_API_KEY" in result["error"]
+
+
+# ============================================================================
+# get_kr_economic_indicator
+# ============================================================================
+
+
+class TestGetKrEconomicIndicator:
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_gdp(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_economic_indicator("gdp_growth", "2023-01-01", "2024-12-31")
+
+        assert result["data_type"] == "kr_economic_indicator"
+        assert result["indicator"] == "gdp_growth"
+        assert result["count"] == 2
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_cpi(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_economic_indicator("cpi", "2024-01-01", "2024-12-31")
+
+        assert result["indicator"] == "cpi"
+
+    def test_unknown_indicator(self):
+        result = get_kr_economic_indicator("unknown", "2024-01-01", "2024-12-31")
+
+        assert "error" in result
+        assert "알 수 없는 지표" in result["error"]
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_cycle_override(self, mock_client_cls, mock_ecos_response):
+        mock_client = _mock_httpx_get(mock_ecos_response)
+        mock_client_cls.return_value = mock_client
+
+        get_kr_economic_indicator("cpi", "2024-01-01", "2024-12-31", cycle="A")
+
+        call_url = mock_client.get.call_args[0][0]
+        assert "/A/" in call_url
+
+
+# ============================================================================
+# get_kr_exchange_rate
+# ============================================================================
+
+
+class TestGetKrExchangeRate:
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_usd(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_exchange_rate("USD", "2024-01-01", "2024-12-31")
+
+        assert result["data_type"] == "kr_exchange_rate"
+        assert result["currency"] == "USD"
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_jpy(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_exchange_rate("jpy", "2024-01-01", "2024-12-31")
+
+        assert result["currency"] == "JPY"
+
+    def test_unknown_currency(self):
+        result = get_kr_exchange_rate("XYZ", "2024-01-01", "2024-12-31")
+
+        assert "error" in result
+        assert "알 수 없는 통화" in result["error"]
+
+
+# ============================================================================
+# get_kr_treasury_yield
+# ============================================================================
+
+
+class TestGetKrTreasuryYield:
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_10y(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_treasury_yield("10Y", "2024-01-01", "2024-12-31")
+
+        assert result["data_type"] == "kr_treasury_yield"
+        assert result["maturity"] == "10Y"
+        assert result["count"] == 2
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_3y(self, mock_client_cls, mock_ecos_response):
+        mock_client_cls.return_value = _mock_httpx_get(mock_ecos_response)
+
+        result = get_kr_treasury_yield("3y", "2024-01-01", "2024-12-31")
+
+        assert result["maturity"] == "3Y"
+
+    def test_unknown_maturity(self):
+        result = get_kr_treasury_yield("99Y", "2024-01-01", "2024-12-31")
+
+        assert "error" in result
+        assert "알 수 없는 만기" in result["error"]
+
+    @patch("mcp_servers.korean.kr_ecos_mcp_server.httpx.Client")
+    def test_http_error(self, mock_client_cls):
+        mock_client = MagicMock()
+        mock_client.__enter__ = MagicMock(return_value=mock_client)
+        mock_client.__exit__ = MagicMock(return_value=False)
+        mock_client.get.side_effect = httpx.HTTPError("connection failed")
+        mock_client_cls.return_value = mock_client
+
+        result = get_kr_treasury_yield("10Y", "2024-01-01", "2024-12-31")
+
+        assert "error" in result


### PR DESCRIPTION
## 요약
Closes #10
한국은행 ECOS API를 직접 호출하는 kr_ecos MCP 서버를 추가하여 한국 매크로 데이터를 PTC 에이전트에서 조회 가능하게 한다.

## 변경 사항
- `mcp_servers/korean/kr_ecos_mcp_server.py`: FastMCP 서버 4개 도구 (기준금리, 경제지표, 환율, 국고채)
- `tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py`: 15개 단위 테스트 (httpx mock)
- `agent_config.yaml`: `kr_ecos` MCP 서버 등록 (ECOS_API_KEY 환경변수 전달)
- `.env.example`: `ECOS_API_KEY` 항목 추가

## 기술적 판단
- **httpx 직접 호출**: ECOS 공식 Python 패키지 없음. httpx는 이미 프로젝트 의존성이므로 추가 의존성 없이 직접 HTTP 호출. pyproject.toml 변경 불필요.
- **프리셋 기반 지표 조회**: ECOS API의 통계표코드/항목코드 조합이 복잡하므로, 주요 8개 경제지표를 프리셋으로 제공하고 indicator 이름으로 접근. 커스텀 코드 조합은 향후 확장 가능.
- **동기 패턴**: 기존 yfinance/pykrx MCP 서버와 동일하게 동기 함수 + FastMCP. httpx.Client(동기)로 호출.
- **국고채 만기 매핑**: 1Y~50Y 8개 만기를 사전 매핑. kr-dcf-model 스킬에서 무위험수익률로 직접 사용 가능.

## 검증
- `uv run pytest tests/unit/mcp_servers/korean/test_kr_ecos_mcp.py -v` → 15개 전체 통과
- `uv run pytest tests/unit/ -v` → 2913개 전체 통과 (리그레션 없음)
- `ruff check` → All checks passed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 한국은행 ECOS에서 기준금리, 경제지표, 환율, 국고채 수익률 등 거시경제 데이터에 접근할 수 있는 새로운 도구가 추가되었습니다.
  * 특정 기간 및 주기별로 다양한 경제 데이터를 조회할 수 있습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->