### PR TITLE
feat: LLM 비용·지연 관측 콜백 + Claude 단일 라우팅

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -6,15 +6,16 @@
 # For non agent related config, see config.yaml
 
 llm:
+  # FORK: Stage A — Claude 단일 생태계로 전환 (DEPLOYMENT_STRATEGY.md v3.1 §3.1)
+  # 역할 분리: Sonnet = PTC 메인 + Research, Haiku = Flash + 보조 경로 + fallback
+  # 프로바이더 다각화는 S2 트리거(월 LLM > $250 3개월) 시 별도 Issue로 진행.
   # Model name from src/llms/manifest/models.json
-  name: "qwen3.5-plus"
-  flash: "qwen3.6-flash"
-  compaction: "qwen3.6-flash" # defaults to flash model
-  fetch: "qwen3.6-flash"         # defaults to flash model
+  name: "claude-sonnet-4-6"
+  flash: "claude-haiku-4-5"
+  compaction: "claude-haiku-4-5" # defaults to flash model
+  fetch: "claude-haiku-4-5"      # defaults to flash model
   fallback:
-    - "kimi-k2.5"
-    - "minimax-m2.7"
-    - "glm-5-turbo"
+    - "claude-haiku-4-5"
 
 sandbox:
   # Provider selection: "daytona" (cloud) or "docker" (local).

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -122,4 +122,5 @@ addopts = "-m 'not integration and not slow'"
 dev = [
     "pytest>=9.0.1",
     "pytest-asyncio>=1.3.0",
+    "ruff>=0.15.11",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -81,7 +81,7 @@ ptc-cli = { path = "libs/ptc-cli", editable = true }
 
 [project.optional-dependencies]
 dev = [
-    "ruff",
+    "ruff>=0.15.11",
     "black>=24.2.0",
     "langgraph-cli[inmem]>=0.2.10",
 ]

--- a/src/llms/callbacks.py
+++ b/src/llms/callbacks.py
@@ -1,0 +1,354 @@
+# FORK: Stage A 관측 레이어 — 토큰/비용/지연을 구조화 로깅하는 LangChain 콜백
+"""Cost and latency tracking callback for LLM calls.
+
+이 콜백은 기존 ``PerCallTokenTracker`` 와 **병행** 사용된다. 역할 구분:
+
+- ``PerCallTokenTracker`` (업스트림): per-call 토큰 기록 + billing_type 추적
+- ``CostTrackingCallback`` (FORK): 각 호출의 **비용 / 지연 / 역할 태그**를 계산해서
+  stdout + JSONL 파일로 적재, 나중에 CloudWatch 로 내보낼 수 있게 구조화
+
+DEPLOYMENT_STRATEGY.md v3.1 §3.1, §6 Stage A 참조.
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+from uuid import UUID
+
+from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.outputs import LLMResult
+
+from src.llms.pricing_utils import (
+    calculate_total_cost,
+    detect_provider_for_model,
+    find_model_pricing,
+)
+from src.llms.token_counter import extract_token_usage
+
+logger = logging.getLogger(__name__)
+
+
+_ENV_LOG_DIR = "COST_LOG_DIR"
+_ENV_LOG_ENABLED = "COST_LOG_ENABLED"
+_ENV_CLOUDWATCH_ENABLED = "AWS_CLOUDWATCH_METRICS"
+_DEFAULT_LOG_DIR = "./log/cost"
+
+
+class CostTrackingCallback(BaseCallbackHandler):
+    """각 LLM 호출의 비용/지연/역할을 기록하는 LangChain 콜백.
+
+    한 워크플로우(thread)당 하나를 만들어 그래프 config 의 ``callbacks`` 리스트에
+    태운다. ``PerCallTokenTracker`` 와 독립적으로 동작하므로 기존 토큰 추적
+    파이프라인은 그대로 유지된다.
+
+    기록 채널:
+    - 항상: 구조화된 JSON 로그 라인 (logger.info)
+    - ``COST_LOG_ENABLED=true`` (기본값): ``./log/cost/YYYY-MM-DD/HHMM-thread.jsonl``
+      에 append. ``COST_LOG_DIR`` 환경변수로 디렉토리 오버라이드.
+    - ``AWS_CLOUDWATCH_METRICS=true`` 시 ``boto3`` 로 custom metric 발행
+      (Stage D 에서 실제 연결; 여기서는 stub 만 제공).
+
+    태그 전파는 LLM 인스턴스의 ``metadata`` 를 통해 일어난다. 호출자가
+    ``llm.bind(metadata={"tag": "flash"})`` 또는 ``chain.with_config(
+    {"metadata": {"tag": "research"}})`` 로 지정하면 ``on_chat_model_start``
+    에서 잡아낸다. metadata 가 없으면 ``tag="unknown"`` 으로 기록된다.
+    """
+
+    def __init__(
+        self,
+        thread_id: str,
+        default_tag: str = "unknown",
+        log_dir: Optional[str] = None,
+        cloudwatch_namespace: str = "langalpha/llm",
+    ) -> None:
+        super().__init__()
+        self.thread_id = thread_id
+        self.default_tag = default_tag
+        self.cloudwatch_namespace = cloudwatch_namespace
+
+        self._lock = threading.Lock()
+        # run_id → start timestamp (perf_counter ns)
+        self._run_started_ns: Dict[UUID, int] = {}
+        # run_id → metadata captured at start (tag, billing_type, model)
+        self._run_metadata: Dict[UUID, Dict[str, Any]] = {}
+        # 완료된 호출 기록 (테스트 및 디버깅에 유용)
+        self.records: List[Dict[str, Any]] = []
+
+        self.log_enabled = (
+            os.getenv(_ENV_LOG_ENABLED, "true").lower() == "true"
+        )
+        resolved_dir = log_dir or os.getenv(_ENV_LOG_DIR, _DEFAULT_LOG_DIR)
+        self.log_dir = Path(resolved_dir)
+        self.cloudwatch_enabled = (
+            os.getenv(_ENV_CLOUDWATCH_ENABLED, "false").lower() == "true"
+        )
+
+    # ------------------------------------------------------------------
+    # LangChain 콜백 훅
+    # ------------------------------------------------------------------
+
+    def on_chat_model_start(
+        self,
+        serialized: Dict[str, Any],
+        messages: List[Any],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        self._record_start(run_id, serialized, metadata)
+
+    def on_llm_start(
+        self,
+        serialized: Dict[str, Any],
+        prompts: List[str],
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        tags: Optional[List[str]] = None,
+        metadata: Optional[Dict[str, Any]] = None,
+        **kwargs: Any,
+    ) -> None:
+        # Chat/text LLM 모두 대응. chat 모델은 ``on_chat_model_start`` 가
+        # 먼저 호출되므로 이 경로는 레거시 호출용.
+        self._record_start(run_id, serialized, metadata)
+
+    def on_llm_end(
+        self,
+        response: LLMResult,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        try:
+            self._record_end(run_id, response)
+        except Exception as e:
+            # 콜백 실패가 실제 쿼리를 막지 않도록 방어
+            logger.warning(
+                "CostTrackingCallback failed to record end for run_id=%s: %s",
+                run_id,
+                e,
+            )
+            with self._lock:
+                self._run_started_ns.pop(run_id, None)
+                self._run_metadata.pop(run_id, None)
+
+    def on_llm_error(
+        self,
+        error: BaseException,
+        *,
+        run_id: UUID,
+        parent_run_id: Optional[UUID] = None,
+        **kwargs: Any,
+    ) -> None:
+        with self._lock:
+            self._run_started_ns.pop(run_id, None)
+            self._run_metadata.pop(run_id, None)
+
+    # ------------------------------------------------------------------
+    # 내부 기록 로직
+    # ------------------------------------------------------------------
+
+    def _record_start(
+        self,
+        run_id: UUID,
+        serialized: Dict[str, Any],
+        metadata: Optional[Dict[str, Any]],
+    ) -> None:
+        now_ns = time.perf_counter_ns()
+        md: Dict[str, Any] = {
+            "tag": self.default_tag,
+            "billing_type": "platform",
+            "model": None,
+        }
+        if metadata:
+            if "tag" in metadata:
+                md["tag"] = metadata["tag"]
+            if "billing_type" in metadata:
+                md["billing_type"] = metadata["billing_type"]
+        # LangChain serialized 에서 model 이름 추출 시도
+        if serialized:
+            kwargs = serialized.get("kwargs") or {}
+            model_name = (
+                kwargs.get("model")
+                or kwargs.get("model_name")
+                or serialized.get("name")
+            )
+            if model_name:
+                md["model"] = model_name
+        with self._lock:
+            self._run_started_ns[run_id] = now_ns
+            self._run_metadata[run_id] = md
+
+    def _record_end(self, run_id: UUID, response: LLMResult) -> None:
+        end_ns = time.perf_counter_ns()
+        with self._lock:
+            start_ns = self._run_started_ns.pop(run_id, None)
+            md = self._run_metadata.pop(run_id, None) or {}
+        if start_ns is None:
+            logger.debug(
+                "CostTrackingCallback: end without start (run_id=%s)", run_id
+            )
+            return
+
+        latency_ms = (end_ns - start_ns) / 1_000_000.0
+
+        token_usage = _safe_extract_tokens(response)
+        model_name = (
+            token_usage.get("model_name")
+            or md.get("model")
+            or _extract_model_from_response(response)
+            or "unknown"
+        )
+
+        cost_info = _compute_cost(
+            model_name=model_name,
+            billing_type=md.get("billing_type", "platform"),
+            token_usage=token_usage,
+        )
+
+        record = {
+            "thread_id": self.thread_id,
+            "timestamp": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+            "run_id": str(run_id),
+            "tag": md.get("tag", self.default_tag),
+            "model": model_name,
+            "billing_type": md.get("billing_type", "platform"),
+            "input_tokens": token_usage.get("input_tokens", 0),
+            "output_tokens": token_usage.get("output_tokens", 0),
+            "total_tokens": token_usage.get("total_tokens", 0),
+            "cost_usd": cost_info.get("total_cost", 0.0),
+            "cost_error": cost_info.get("error"),
+            "latency_ms": round(latency_ms, 2),
+        }
+        self.records.append(record)
+
+        logger.info("llm_cost %s", json.dumps(record, ensure_ascii=False))
+
+        if self.log_enabled:
+            self._append_jsonl(record)
+
+        if self.cloudwatch_enabled:
+            self._emit_cloudwatch(record)
+
+    # ------------------------------------------------------------------
+    # 출력 채널
+    # ------------------------------------------------------------------
+
+    def _append_jsonl(self, record: Dict[str, Any]) -> None:
+        now = datetime.now(timezone.utc)
+        day_dir = self.log_dir / now.strftime("%Y-%m-%d")
+        try:
+            day_dir.mkdir(parents=True, exist_ok=True)
+        except OSError as e:
+            logger.warning(
+                "CostTrackingCallback: cannot create log dir %s: %s", day_dir, e
+            )
+            return
+
+        last4 = self.thread_id[-4:] if len(self.thread_id) >= 4 else self.thread_id
+        filename = f"{now.strftime('%H%M')}-{last4}.jsonl"
+        path = day_dir / filename
+        try:
+            with path.open("a", encoding="utf-8") as f:
+                f.write(json.dumps(record, ensure_ascii=False) + "\n")
+        except OSError as e:
+            logger.warning(
+                "CostTrackingCallback: cannot write %s: %s", path, e
+            )
+
+    def _emit_cloudwatch(self, record: Dict[str, Any]) -> None:
+        """Stage D 에서 실제 boto3 호출로 채운다. 현재는 디버그 로그만."""
+        logger.debug(
+            "cloudwatch_stub namespace=%s record=%s",
+            self.cloudwatch_namespace,
+            record,
+        )
+
+
+# ----------------------------------------------------------------------
+# 헬퍼: 토큰 추출 / 비용 계산 (방어적 래퍼)
+# ----------------------------------------------------------------------
+
+
+def _safe_extract_tokens(response: Any) -> Dict[str, Any]:
+    """``extract_token_usage`` 가 예외를 던져도 빈 dict 를 반환한다."""
+    try:
+        generations = getattr(response, "generations", None)
+        if generations:
+            for gen_list in generations:
+                for gen in gen_list:
+                    message = getattr(gen, "message", None)
+                    if message is not None:
+                        return extract_token_usage(message)
+        return extract_token_usage(response)
+    except Exception as e:
+        logger.debug("extract_token_usage failed: %s", e)
+        return {}
+
+
+def _extract_model_from_response(response: Any) -> Optional[str]:
+    llm_output = getattr(response, "llm_output", None)
+    if isinstance(llm_output, dict):
+        return llm_output.get("model_name") or llm_output.get("model")
+    return None
+
+
+def _compute_cost(
+    model_name: str,
+    billing_type: str,
+    token_usage: Dict[str, Any],
+) -> Dict[str, Any]:
+    """pricing_utils 로 비용 계산. 실패 시 ``{'total_cost': 0.0, 'error': ...}``."""
+    try:
+        provider = detect_provider_for_model(model_name, billing_type=billing_type)
+        pricing = find_model_pricing(model_name, provider=provider)
+        if not pricing:
+            return {"total_cost": 0.0, "error": "pricing_not_found"}
+
+        input_tokens = token_usage.get("input_tokens", 0) or 0
+        output_tokens = token_usage.get("output_tokens", 0) or 0
+        cached = token_usage.get("cached_tokens", 0) or 0
+        cache_5m = token_usage.get("cache_5m_tokens", 0) or 0
+        cache_1h = token_usage.get("cache_1h_tokens", 0) or 0
+
+        return calculate_total_cost(
+            input_tokens=input_tokens,
+            output_tokens=output_tokens,
+            cached_tokens=cached,
+            cache_5m_tokens=cache_5m,
+            cache_1h_tokens=cache_1h,
+            pricing=pricing,
+        )
+    except Exception as e:
+        logger.debug("cost calculation failed for %s: %s", model_name, e)
+        return {"total_cost": 0.0, "error": str(e)}
+
+
+# ----------------------------------------------------------------------
+# 팩토리 헬퍼 (call site 에서 한 줄로 생성)
+# ----------------------------------------------------------------------
+
+
+def init_cost_tracker(
+    thread_id: str,
+    default_tag: str = "unknown",
+) -> CostTrackingCallback:
+    """Stage A 표준 진입점. 워크플로우 핸들러에서 호출."""
+    return CostTrackingCallback(thread_id=thread_id, default_tag=default_tag)
+
+
+__all__ = [
+    "CostTrackingCallback",
+    "init_cost_tracker",
+]

--- a/src/llms/callbacks.py
+++ b/src/llms/callbacks.py
@@ -50,8 +50,10 @@ class CostTrackingCallback(BaseCallbackHandler):
 
     기록 채널:
     - 항상: 구조화된 JSON 로그 라인 (logger.info)
-    - ``COST_LOG_ENABLED=true`` (기본값): ``./log/cost/YYYY-MM-DD/HHMM-thread.jsonl``
-      에 append. ``COST_LOG_DIR`` 환경변수로 디렉토리 오버라이드.
+    - ``COST_LOG_ENABLED=true`` (기본값): ``./log/cost/YYYY-MM-DD/HHMM-{last4}.jsonl``
+      에 append. 파일명은 ``result_logger.py`` 와 동일하게 thread_id 의 마지막
+      4자리를 사용 (짧은 윈도우 내 충돌 확률 낮음). ``COST_LOG_DIR`` 환경변수로
+      디렉토리 오버라이드.
     - ``AWS_CLOUDWATCH_METRICS=true`` 시 ``boto3`` 로 custom metric 발행
       (Stage D 에서 실제 연결; 여기서는 stub 만 제공).
 

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -637,6 +637,7 @@ def build_graph_config(
     recursion_limit: int,
     plan_mode: bool | None = None,
     extra_configurable: dict | None = None,
+    cost_callback=None,  # FORK: Stage A 비용 관측 콜백 (src/llms/callbacks.py)
 ) -> dict:
     """Build the LangGraph ``config`` dict shared by flash and PTC handlers.
 
@@ -688,6 +689,10 @@ def build_graph_config(
     callbacks: list = []
     if token_callback:
         callbacks.append(token_callback)
+
+    # FORK: Stage A — 비용/지연 관측 콜백 (있을 때만)
+    if cost_callback:
+        callbacks.append(cost_callback)
 
     langsmith_tracer = get_filtered_langsmith_tracer()
     if langsmith_tracer:

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -194,6 +194,10 @@ async def astream_flash_workflow(
         # =================================================================
 
         token_callback, tool_tracker = init_tracking(thread_id)
+        # FORK: Stage A — 비용/지연 관측 콜백 (Flash 모드 전용 태그)
+        from src.llms.callbacks import init_cost_tracker
+
+        cost_callback = init_cost_tracker(thread_id, default_tag="flash")
 
         # =================================================================
         # Build Flash Agent Graph
@@ -319,6 +323,7 @@ async def astream_flash_workflow(
             effective_model=effective_model,
             is_byok=is_byok,
             recursion_limit=get_flash_recursion_limit(),
+            cost_callback=cost_callback,  # FORK: Stage A
         )
 
         # Create stream handler

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -31,6 +31,7 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
+from src.llms.callbacks import init_cost_tracker  # FORK: Stage A
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -195,8 +196,6 @@ async def astream_flash_workflow(
 
         token_callback, tool_tracker = init_tracking(thread_id)
         # FORK: Stage A — 비용/지연 관측 콜백 (Flash 모드 전용 태그)
-        from src.llms.callbacks import init_cost_tracker
-
         cost_callback = init_cost_tracker(thread_id, default_tag="flash")
 
         # =================================================================

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -324,6 +324,10 @@ async def astream_ptc_workflow(
         # =====================================================================
 
         token_callback, tool_tracker = init_tracking(thread_id)
+        # FORK: Stage A — 비용/지연 관측 콜백 (PTC 메인 루프 태그)
+        from src.llms.callbacks import init_cost_tracker
+
+        cost_callback = init_cost_tracker(thread_id, default_tag="ptc")
 
         _mark_phase("db_setup")
 
@@ -662,6 +666,7 @@ async def astream_ptc_workflow(
             is_byok=is_byok,
             recursion_limit=get_ptc_recursion_limit(),
             plan_mode=effective_plan_mode,
+            cost_callback=cost_callback,  # FORK: Stage A
         )
 
         # Extract background task registry from orchestrator (single source of truth for SSE events)

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -37,6 +37,7 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
+from src.llms.callbacks import init_cost_tracker  # FORK: Stage A
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -325,8 +326,6 @@ async def astream_ptc_workflow(
 
         token_callback, tool_tracker = init_tracking(thread_id)
         # FORK: Stage A — 비용/지연 관측 콜백 (PTC 메인 루프 태그)
-        from src.llms.callbacks import init_cost_tracker
-
         cost_callback = init_cost_tracker(thread_id, default_tag="ptc")
 
         _mark_phase("db_setup")

--- a/tests/unit/llms/test_callbacks.py
+++ b/tests/unit/llms/test_callbacks.py
@@ -1,0 +1,181 @@
+# FORK: Stage A 단위 테스트 — CostTrackingCallback 동작 검증
+"""Tests for src.llms.callbacks.CostTrackingCallback."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from unittest.mock import patch
+from uuid import uuid4
+
+from src.llms.callbacks import CostTrackingCallback, init_cost_tracker
+
+
+def _fake_response(input_tokens: int = 100, output_tokens: int = 30):
+    """Build a minimal LLMResult-like object with usage_metadata."""
+
+    class _Msg:
+        usage_metadata = {
+            "input_tokens": input_tokens,
+            "output_tokens": output_tokens,
+            "total_tokens": input_tokens + output_tokens,
+        }
+
+    class _Gen:
+        message = _Msg()
+
+    class _Resp:
+        generations = [[_Gen()]]
+        llm_output = {"model_name": "claude-sonnet-4-6"}
+
+    return _Resp()
+
+
+class TestCostTrackingCallback:
+    """기본 콜백 동작."""
+
+    def test_records_basic_call_with_pricing(self, tmp_path, monkeypatch):
+        """정상 호출 시 토큰/비용/지연이 기록된다."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        cb = CostTrackingCallback(thread_id="abcd1234", default_tag="ptc")
+
+        run_id = uuid4()
+        with patch(
+            "src.llms.callbacks.find_model_pricing",
+            return_value={"input": 3.0, "output": 15.0, "unit": "per_1m_tokens"},
+        ), patch(
+            "src.llms.callbacks.detect_provider_for_model",
+            return_value="anthropic",
+        ):
+            cb.on_chat_model_start(
+                serialized={"name": "ChatAnthropic", "kwargs": {"model": "claude-sonnet-4-6"}},
+                messages=[],
+                run_id=run_id,
+                metadata={"tag": "research", "billing_type": "byok"},
+            )
+            cb.on_llm_end(_fake_response(input_tokens=1000, output_tokens=200), run_id=run_id)
+
+        assert len(cb.records) == 1
+        rec = cb.records[0]
+        assert rec["tag"] == "research"
+        assert rec["billing_type"] == "byok"
+        assert rec["model"] == "claude-sonnet-4-6"
+        assert rec["input_tokens"] == 1000
+        assert rec["output_tokens"] == 200
+        assert rec["cost_usd"] > 0  # 1000 in × $3/M + 200 out × $15/M = $0.003 + $0.003
+        assert rec["latency_ms"] >= 0
+
+    def test_default_tag_when_metadata_missing(self, tmp_path, monkeypatch):
+        """metadata 없이 호출돼도 default_tag 가 기록된다."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        cb = CostTrackingCallback(thread_id="t1234", default_tag="flash")
+
+        run_id = uuid4()
+        with patch(
+            "src.llms.callbacks.find_model_pricing", return_value=None
+        ):
+            cb.on_chat_model_start(
+                serialized={"name": "ChatAnthropic"},
+                messages=[],
+                run_id=run_id,
+                metadata=None,
+            )
+            cb.on_llm_end(_fake_response(), run_id=run_id)
+
+        assert cb.records[0]["tag"] == "flash"
+
+    def test_missing_pricing_does_not_crash(self, tmp_path, monkeypatch):
+        """pricing 못 찾으면 cost=0 + error 로 기록되고 예외 없음."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        cb = CostTrackingCallback(thread_id="x9999", default_tag="ptc")
+
+        run_id = uuid4()
+        with patch(
+            "src.llms.callbacks.find_model_pricing", return_value=None
+        ):
+            cb.on_chat_model_start(
+                serialized={"name": "ChatAnthropic"},
+                messages=[],
+                run_id=run_id,
+                metadata={"tag": "ptc"},
+            )
+            cb.on_llm_end(_fake_response(), run_id=run_id)
+
+        rec = cb.records[0]
+        assert rec["cost_usd"] == 0.0
+        assert rec["cost_error"] == "pricing_not_found"
+
+    def test_jsonl_file_written(self, tmp_path, monkeypatch):
+        """COST_LOG_ENABLED=true 면 JSONL 파일이 생성된다."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("COST_LOG_ENABLED", "true")
+        cb = CostTrackingCallback(thread_id="abcdef9876", default_tag="ptc")
+
+        run_id = uuid4()
+        with patch(
+            "src.llms.callbacks.find_model_pricing", return_value=None
+        ):
+            cb.on_chat_model_start(
+                serialized={"name": "ChatAnthropic"},
+                messages=[],
+                run_id=run_id,
+                metadata={"tag": "ptc"},
+            )
+            cb.on_llm_end(_fake_response(), run_id=run_id)
+
+        # tmp_path 하위에 YYYY-MM-DD/HHMM-9876.jsonl 파일 생성 확인
+        files = list(Path(tmp_path).rglob("*.jsonl"))
+        assert len(files) == 1
+        line = files[0].read_text(encoding="utf-8").strip()
+        rec = json.loads(line)
+        assert rec["thread_id"] == "abcdef9876"
+        assert rec["tag"] == "ptc"
+
+    def test_log_disabled_does_not_write(self, tmp_path, monkeypatch):
+        """COST_LOG_ENABLED=false 면 JSONL 파일이 생성되지 않는다."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("COST_LOG_ENABLED", "false")
+        cb = CostTrackingCallback(thread_id="zz9999", default_tag="flash")
+
+        run_id = uuid4()
+        with patch(
+            "src.llms.callbacks.find_model_pricing", return_value=None
+        ):
+            cb.on_chat_model_start(
+                serialized={}, messages=[], run_id=run_id, metadata=None
+            )
+            cb.on_llm_end(_fake_response(), run_id=run_id)
+
+        files = list(Path(tmp_path).rglob("*.jsonl"))
+        assert files == []
+
+    def test_on_llm_error_clears_run_state(self, tmp_path, monkeypatch):
+        """LLM 에러 발생 시 run state 정리되고 records 에는 추가 안 됨."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        cb = CostTrackingCallback(thread_id="errr0001", default_tag="ptc")
+
+        run_id = uuid4()
+        cb.on_chat_model_start(
+            serialized={}, messages=[], run_id=run_id, metadata=None
+        )
+        assert run_id in cb._run_started_ns
+        cb.on_llm_error(RuntimeError("boom"), run_id=run_id)
+        assert run_id not in cb._run_started_ns
+        assert cb.records == []
+
+    def test_end_without_start_is_safe(self, monkeypatch, tmp_path):
+        """on_llm_end 가 짝 없는 run_id 로 와도 예외 없이 무시된다."""
+        monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        cb = CostTrackingCallback(thread_id="orph0002", default_tag="ptc")
+        cb.on_llm_end(_fake_response(), run_id=uuid4())
+        assert cb.records == []
+
+
+class TestInitCostTracker:
+    """팩토리 헬퍼."""
+
+    def test_returns_callback_instance(self):
+        cb = init_cost_tracker(thread_id="th-xyz", default_tag="research")
+        assert isinstance(cb, CostTrackingCallback)
+        assert cb.thread_id == "th-xyz"
+        assert cb.default_tag == "research"

--- a/tests/unit/llms/test_callbacks.py
+++ b/tests/unit/llms/test_callbacks.py
@@ -37,6 +37,7 @@ class TestCostTrackingCallback:
     def test_records_basic_call_with_pricing(self, tmp_path, monkeypatch):
         """정상 호출 시 토큰/비용/지연이 기록된다."""
         monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("COST_LOG_ENABLED", "true")
         cb = CostTrackingCallback(thread_id="abcd1234", default_tag="ptc")
 
         run_id = uuid4()
@@ -68,6 +69,7 @@ class TestCostTrackingCallback:
     def test_default_tag_when_metadata_missing(self, tmp_path, monkeypatch):
         """metadata 없이 호출돼도 default_tag 가 기록된다."""
         monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("COST_LOG_ENABLED", "true")
         cb = CostTrackingCallback(thread_id="t1234", default_tag="flash")
 
         run_id = uuid4()
@@ -87,6 +89,7 @@ class TestCostTrackingCallback:
     def test_missing_pricing_does_not_crash(self, tmp_path, monkeypatch):
         """pricing 못 찾으면 cost=0 + error 로 기록되고 예외 없음."""
         monkeypatch.setenv("COST_LOG_DIR", str(tmp_path))
+        monkeypatch.setenv("COST_LOG_ENABLED", "true")
         cb = CostTrackingCallback(thread_id="x9999", default_tag="ptc")
 
         run_id = uuid4()

--- a/uv.lock
+++ b/uv.lock
@@ -3483,6 +3483,7 @@ test = [
 dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
+    { name = "ruff" },
 ]
 
 [package.metadata]
@@ -3557,6 +3558,7 @@ provides-extras = ["dev", "test"]
 dev = [
     { name = "pytest", specifier = ">=9.0.1" },
     { name = "pytest-asyncio", specifier = ">=1.3.0" },
+    { name = "ruff", specifier = ">=0.15.11" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -3536,7 +3536,7 @@ requires-dist = [
     { name = "redis", specifier = ">=5.0.0" },
     { name = "requests", specifier = ">=2.32.5" },
     { name = "rich", specifier = ">=14.2.0" },
-    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "ruff", marker = "extra == 'dev'", specifier = ">=0.15.11" },
     { name = "scikit-learn" },
     { name = "scipy" },
     { name = "scrapling", extras = ["fetchers"], specifier = "==0.4.7" },


### PR DESCRIPTION
## 요약

Closes #12

LLM 호출의 **토큰 / 비용 / 지연** 을 구조화 기록하는 LangChain 콜백을 추가하고, 모델 라우팅을 **Claude 단일 생태계 (Haiku Flash + Sonnet PTC·Research)** 로 정리한다. 멀티 프로바이더 전환은 추후에 별도 Issue 로 미룬다.

## 변경 사항

### 신규 파일

- `src/llms/callbacks.py` — `CostTrackingCallback` (LangChain `BaseCallbackHandler`) + `init_cost_tracker` 팩토리
- `tests/unit/llms/test_callbacks.py` — 단위 테스트 8개

### 수정 파일 (FORK 주석 명시)

- `src/server/handlers/chat/_common.py::build_graph_config` — `cost_callback` 옵셔널 파라미터 추가, callbacks 리스트에 합류
- `src/server/handlers/chat/flash_workflow.py` — `init_cost_tracker(default_tag=\"flash\")` 생성 + `build_graph_config` 에 전달
- `src/server/handlers/chat/ptc_workflow.py` — `init_cost_tracker(default_tag=\"ptc\")` 생성 + `build_graph_config` 에 전달
- `agent_config.yaml::llm` — qwen3.5-plus / kimi-k2.5 등 → `claude-sonnet-4-6` (메인) + `claude-haiku-4-5` (flash/compaction/fetch/fallback)

### 부수 변경

- `pyproject.toml`, `uv.lock` — `ruff>=0.15.11` 을 dev 그룹에 추가 (별도 커밋, lint 워크플로우 재현성 보장)

## 기술적 판단

### 왜 LiteLLM 도입하지 않았나
기존 `src/llms/llm.py` 가 이미 LangChain 기반 multi-SDK 팩토리라 LiteLLM 은 중복 레이어가 된다. fallback 은 기존 `ModelFallbackMiddleware` 가 처리하고, 비용 추적은 LangChain `BaseCallbackHandler` 로 충분하다. YAGNI.

### 왜 Claude 단일인가
실사용자가 있는 프로덕트에서 Together Qwen 등으로 전환하면 **프롬프트 호환성 (`<thinking>` 블록 등) + tool calling 품질 + 한국 금융 도메인 어휘** 리스크를 측정 없이 감수해야 한다. S1 규모에선 비용 차이 (월 $50~150) 가 품질 리스크 대비 감당 가능. 멀티 프로바이더 전환은 추후 시점에 Golden query set 검증과 함께 별도 Issue.

### 왜 PerCallTokenTracker 를 확장하지 않았나
업스트림 파일 수정 최소화 원칙. `CostTrackingCallback` 은 기존 토큰 추적 파이프라인과 **병행 동작**하며, 추가 채널 (비용 / 지연 / JSONL / CloudWatch) 만 담당한다.

### 왜 cost_callback 을 build_graph_config 의 옵셔널 파라미터로 했나
업스트림 호환성. `cost_callback` 인자가 없으면 기존 동작 그대로. 새 기능을 쓰는 호출자만 명시.

## 검증

- [x] `uv run ruff check` 변경 파일 0 경고 (전체 src/ 의 12 에러는 모두 사전 존재 코드)
- [x] `uv run pytest tests/unit/llms/test_callbacks.py -v` 8/8 통과
- [x] `uv run pytest tests/unit/` 전체 2,926 passed (회귀 0)
- [x] 모듈 import 스모크 테스트 — `init_cost_tracker` 인스턴스화 정상
- [x] `agent_config.yaml` YAML 파싱 + 새 모델 태그 적용 확인
- [x] 단위 테스트 시나리오: 정상 호출 / 기본 태그 / pricing 누락 graceful / JSONL 적재 / 로그 비활성 / 에러 정리 / 짝 없는 end / 팩토리 헬퍼

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * LLM 모델 구성을 Claude 기반 설정으로 업그레이드했습니다.
  * LLM 호출의 비용 및 지연시간 추적 기능을 추가했습니다.

* **테스트**
  * 콜백 기능에 대한 포괄적인 단위 테스트를 추가했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->