### PR TITLE
chore: FORK 주석에서 외부 문서 용어 제거

### DIFF
--- a/agent_config.yaml
+++ b/agent_config.yaml
@@ -6,9 +6,8 @@
 # For non agent related config, see config.yaml
 
 llm:
-  # FORK: Stage A — Claude 단일 생태계로 전환 (DEPLOYMENT_STRATEGY.md v3.1 §3.1)
+  # FORK: Claude 단일 벤더 라우팅
   # 역할 분리: Sonnet = PTC 메인 + Research, Haiku = Flash + 보조 경로 + fallback
-  # 프로바이더 다각화는 S2 트리거(월 LLM > $250 3개월) 시 별도 Issue로 진행.
   # Model name from src/llms/manifest/models.json
   name: "claude-sonnet-4-6"
   flash: "claude-haiku-4-5"

--- a/src/llms/callbacks.py
+++ b/src/llms/callbacks.py
@@ -1,4 +1,4 @@
-# FORK: Stage A 관측 레이어 — 토큰/비용/지연을 구조화 로깅하는 LangChain 콜백
+# FORK: LLM 호출의 비용/지연을 구조화해 기록하는 LangChain 콜백
 """Cost and latency tracking callback for LLM calls.
 
 이 콜백은 기존 ``PerCallTokenTracker`` 와 **병행** 사용된다. 역할 구분:
@@ -6,8 +6,6 @@
 - ``PerCallTokenTracker`` (업스트림): per-call 토큰 기록 + billing_type 추적
 - ``CostTrackingCallback`` (FORK): 각 호출의 **비용 / 지연 / 역할 태그**를 계산해서
   stdout + JSONL 파일로 적재, 나중에 CloudWatch 로 내보낼 수 있게 구조화
-
-DEPLOYMENT_STRATEGY.md v3.1 §3.1, §6 Stage A 참조.
 """
 
 from __future__ import annotations
@@ -55,7 +53,7 @@ class CostTrackingCallback(BaseCallbackHandler):
       4자리를 사용 (짧은 윈도우 내 충돌 확률 낮음). ``COST_LOG_DIR`` 환경변수로
       디렉토리 오버라이드.
     - ``AWS_CLOUDWATCH_METRICS=true`` 시 ``boto3`` 로 custom metric 발행
-      (Stage D 에서 실제 연결; 여기서는 stub 만 제공).
+      (현재는 디버그 로그만 찍는 stub; 실제 연결은 배포 인프라 구축 시 추가).
 
     태그 전파는 LLM 인스턴스의 ``metadata`` 를 통해 일어난다. 호출자가
     ``llm.bind(metadata={"tag": "flash"})`` 또는 ``chain.with_config(
@@ -270,7 +268,7 @@ class CostTrackingCallback(BaseCallbackHandler):
             )
 
     def _emit_cloudwatch(self, record: Dict[str, Any]) -> None:
-        """Stage D 에서 실제 boto3 호출로 채운다. 현재는 디버그 로그만."""
+        """CloudWatch custom metric 발행 훅. 현재는 디버그 로그만 찍는 stub."""
         logger.debug(
             "cloudwatch_stub namespace=%s record=%s",
             self.cloudwatch_namespace,
@@ -346,7 +344,7 @@ def init_cost_tracker(
     thread_id: str,
     default_tag: str = "unknown",
 ) -> CostTrackingCallback:
-    """Stage A 표준 진입점. 워크플로우 핸들러에서 호출."""
+    """표준 진입점. 워크플로우 핸들러가 thread 시작 시 한 번 호출."""
     return CostTrackingCallback(thread_id=thread_id, default_tag=default_tag)
 
 

--- a/src/server/handlers/chat/_common.py
+++ b/src/server/handlers/chat/_common.py
@@ -637,7 +637,7 @@ def build_graph_config(
     recursion_limit: int,
     plan_mode: bool | None = None,
     extra_configurable: dict | None = None,
-    cost_callback=None,  # FORK: Stage A 비용 관측 콜백 (src/llms/callbacks.py)
+    cost_callback=None,  # FORK: 비용 관측 콜백 (src/llms/callbacks.py)
 ) -> dict:
     """Build the LangGraph ``config`` dict shared by flash and PTC handlers.
 
@@ -690,7 +690,7 @@ def build_graph_config(
     if token_callback:
         callbacks.append(token_callback)
 
-    # FORK: Stage A — 비용/지연 관측 콜백 (있을 때만)
+    # FORK: 비용/지연 관측 콜백 (있을 때만)
     if cost_callback:
         callbacks.append(cost_callback)
 

--- a/src/server/handlers/chat/flash_workflow.py
+++ b/src/server/handlers/chat/flash_workflow.py
@@ -31,7 +31,7 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
-from src.llms.callbacks import init_cost_tracker  # FORK: Stage A
+from src.llms.callbacks import init_cost_tracker  # FORK: 비용 관측 콜백
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -195,7 +195,7 @@ async def astream_flash_workflow(
         # =================================================================
 
         token_callback, tool_tracker = init_tracking(thread_id)
-        # FORK: Stage A — 비용/지연 관측 콜백 (Flash 모드 전용 태그)
+        # FORK: 비용/지연 관측 콜백 (Flash 모드 전용 태그)
         cost_callback = init_cost_tracker(thread_id, default_tag="flash")
 
         # =================================================================
@@ -322,7 +322,7 @@ async def astream_flash_workflow(
             effective_model=effective_model,
             is_byok=is_byok,
             recursion_limit=get_flash_recursion_limit(),
-            cost_callback=cost_callback,  # FORK: Stage A
+            cost_callback=cost_callback,  # FORK
         )
 
         # Create stream handler

--- a/src/server/handlers/chat/ptc_workflow.py
+++ b/src/server/handlers/chat/ptc_workflow.py
@@ -37,7 +37,7 @@ from src.server.utils.directive_context import (
     build_directive_reminder,
     parse_directive_contexts,
 )
-from src.llms.callbacks import init_cost_tracker  # FORK: Stage A
+from src.llms.callbacks import init_cost_tracker  # FORK: 비용 관측 콜백
 from src.llms.llm import get_input_modalities
 from src.server.utils.multimodal_context import (
     build_attachment_metadata,
@@ -325,7 +325,7 @@ async def astream_ptc_workflow(
         # =====================================================================
 
         token_callback, tool_tracker = init_tracking(thread_id)
-        # FORK: Stage A — 비용/지연 관측 콜백 (PTC 메인 루프 태그)
+        # FORK: 비용/지연 관측 콜백 (PTC 메인 루프 태그)
         cost_callback = init_cost_tracker(thread_id, default_tag="ptc")
 
         _mark_phase("db_setup")
@@ -665,7 +665,7 @@ async def astream_ptc_workflow(
             is_byok=is_byok,
             recursion_limit=get_ptc_recursion_limit(),
             plan_mode=effective_plan_mode,
-            cost_callback=cost_callback,  # FORK: Stage A
+            cost_callback=cost_callback,  # FORK
         )
 
         # Extract background task registry from orchestrator (single source of truth for SSE events)

--- a/tests/unit/llms/test_callbacks.py
+++ b/tests/unit/llms/test_callbacks.py
@@ -1,4 +1,4 @@
-# FORK: Stage A 단위 테스트 — CostTrackingCallback 동작 검증
+# FORK: CostTrackingCallback 단위 테스트
 """Tests for src.llms.callbacks.CostTrackingCallback."""
 
 from __future__ import annotations


### PR DESCRIPTION
## 요약

Closes #14

`# FORK:` 마커 뒤에 따라붙던 **외부 기획 문서 용어** 를 코드와 주석에서 제거. `# FORK:` 마커 자체는 컨벤션이라 유지하고, 뒤의 설명을 **\"이 코드가 무엇을 하는가\"** 로만 바꿈.

## 변경 사항

| 파일 | 내용 |
|---|---|
| `agent_config.yaml` | `llm` 섹션 주석을 단일 줄 \"Claude 단일 벤더 라우팅 / 역할 분리: Sonnet=PTC+Research, Haiku=Flash+보조+fallback\" 로 정리 |
| `src/llms/callbacks.py` | 모듈 상단 FORK 주석을 \"LLM 호출의 비용/지연을 구조화해 기록하는 LangChain 콜백\" 으로. docstring 에서 외부 문서 참조 줄 삭제. CloudWatch stub 주석을 \"현재는 디버그 로그만 찍는 stub; 실제 연결은 배포 인프라 구축 시 추가\" 로. `init_cost_tracker` docstring 도 동작 설명 위주로 |
| `src/server/handlers/chat/_common.py` | `cost_callback` 파라미터 / callbacks append 주변 주석을 \"비용 관측 콜백\" / \"비용/지연 관측 콜백\" 으로 |
| `src/server/handlers/chat/flash_workflow.py` | import / 콜백 생성 / `build_graph_config` 호출부 주석을 동작 설명으로 |
| `src/server/handlers/chat/ptc_workflow.py` | 같은 패턴 |
| `tests/unit/llms/test_callbacks.py` | 파일 헤더를 `# FORK: CostTrackingCallback 단위 테스트` 로 |

## 기술적 판단

### 왜 제거했나
- 기획 정리가 변경되거나 표기가 바뀌면 코드 주석이 silent stale 됨
- 코드만 읽는 사람 (상류 기여자, 미래의 본인) 은 외부 표기 의미를 알 길이 없음
- 직전 PR 머지 시 코드 단 잔재가 그대로 들어가 버림

### 왜 `# FORK:` 마커는 유지했나
포크 컨벤션 (CLAUDE.md) — 업스트림 파일 수정 지점에 `# FORK: 설명` 을 붙여 상류 머지 시 fork 변경 지점을 식별. 마커 자체는 유지하고 뒤의 설명만 자기-설명적으로.

## 검증

- [x] `grep -rn` 으로 변경 파일에서 외부 기획 표기 잔존 0건 (PKCE `S256`, workspace 이름 `WS2` 등 false positive 만 남음)
- [x] `uv run ruff check` 변경 파일 0 경고
- [x] `uv run pytest tests/unit/llms/test_callbacks.py -v` 8/8 통과
- [x] `uv run pytest tests/unit/` 전체 2,926 passed (회귀 0)

## 관련

- Closes #14
- 후속 정책: 코드 주석 / docstring 에서 외부 기획 단위 표기 금지. 로드맵 추적은 GitHub Milestones / Issue / PR 본문에서만.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **문서화**
  * 설정 및 코드 주석을 업데이트하여 시스템 아키텍처 및 현재 구현 상태에 대한 명확성을 개선했습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->