### PR TITLE
feat: 대시보드 추천 prompt 한국화 + 온보딩 wizard 한국어 검증

### DIFF
--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -213,7 +213,9 @@
     "suggestionEarnings": "Summarize Apple's earnings",
     "suggestionCompare": "Compare TSLA vs BYD",
     "suggestionVolatility": "Predict market volatility",
-    "suggestionPortfolio": "Analyze my portfolio risk"
+    "suggestionPortfolio": "Analyze my portfolio risk",
+    "chatPlaceholder": "Ask AI about market trends...",
+    "chatPlaceholderFull": "Ask AI about market trends, specific stocks, or portfolio analysis..."
   },
   "workspace": {
     "workspaces": "Workspaces",

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -209,7 +209,11 @@
     "watchlist": "Watchlist",
     "personalizeTitle": "Personalize your experience",
     "personalizeDesc": "Chat with our agent to customize watchlists, risk preferences, and alerts",
-    "personalize": "Personalize"
+    "personalize": "Personalize",
+    "suggestionEarnings": "Summarize Apple's earnings",
+    "suggestionCompare": "Compare TSLA vs BYD",
+    "suggestionVolatility": "Predict market volatility",
+    "suggestionPortfolio": "Analyze my portfolio risk"
   },
   "workspace": {
     "workspaces": "Workspaces",

--- a/web/src/locales/ko-KR.json
+++ b/web/src/locales/ko-KR.json
@@ -210,10 +210,12 @@
     "personalizeTitle": "내게 맞춰 사용하기",
     "personalizeDesc": "에이전트와 대화로 관심 종목, 리스크 성향, 알림을 맞춤 설정합니다",
     "personalize": "맞춤 설정",
-    "suggestionEarnings": "삼성전자 최근 실적 요약해줘",
-    "suggestionCompare": "현대차와 기아 비교 분석",
+    "suggestionEarnings": "삼성전자 최근 실적 요약",
+    "suggestionCompare": "현대차 vs 기아 비교 분석",
     "suggestionVolatility": "코스피 변동성 전망",
-    "suggestionPortfolio": "내 포트폴리오 리스크 분석"
+    "suggestionPortfolio": "내 포트폴리오 리스크 분석",
+    "chatPlaceholder": "시장 동향에 대해 AI에게 물어보세요...",
+    "chatPlaceholderFull": "시장 동향, 특정 종목, 포트폴리오 분석을 AI에게 물어보세요..."
   },
   "workspace": {
     "workspaces": "워크스페이스",

--- a/web/src/locales/ko-KR.json
+++ b/web/src/locales/ko-KR.json
@@ -209,7 +209,11 @@
     "watchlist": "관심 종목",
     "personalizeTitle": "내게 맞춰 사용하기",
     "personalizeDesc": "에이전트와 대화로 관심 종목, 리스크 성향, 알림을 맞춤 설정합니다",
-    "personalize": "맞춤 설정"
+    "personalize": "맞춤 설정",
+    "suggestionEarnings": "삼성전자 최근 실적 요약해줘",
+    "suggestionCompare": "현대차와 기아 비교 분석",
+    "suggestionVolatility": "코스피 변동성 전망",
+    "suggestionPortfolio": "내 포트폴리오 리스크 분석"
   },
   "workspace": {
     "workspaces": "워크스페이스",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -209,7 +209,11 @@
     "watchlist": "自选",
     "personalizeTitle": "个性化您的体验",
     "personalizeDesc": "与我们的 AI 助手交流，自定义您的关注列表、风险偏好和提醒",
-    "personalize": "个性化"
+    "personalize": "个性化",
+    "suggestionEarnings": "总结苹果公司最新财报",
+    "suggestionCompare": "比较特斯拉与比亚迪",
+    "suggestionVolatility": "预测市场波动率",
+    "suggestionPortfolio": "分析我的投资组合风险"
   },
   "workspace": {
     "workspaces": "工作区",

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -213,7 +213,9 @@
     "suggestionEarnings": "总结苹果公司最新财报",
     "suggestionCompare": "比较特斯拉与比亚迪",
     "suggestionVolatility": "预测市场波动率",
-    "suggestionPortfolio": "分析我的投资组合风险"
+    "suggestionPortfolio": "分析我的投资组合风险",
+    "chatPlaceholder": "向 AI 询问市场趋势……",
+    "chatPlaceholderFull": "向 AI 询问市场趋势、特定股票或投资组合分析……"
   },
   "workspace": {
     "workspaces": "工作区",

--- a/web/src/pages/Dashboard/components/ChatInputCard.tsx
+++ b/web/src/pages/Dashboard/components/ChatInputCard.tsx
@@ -1,15 +1,17 @@
-import React, { useState, useRef } from 'react';
+import React, { useMemo, useState, useRef } from 'react';
+import { useTranslation } from 'react-i18next';
 import ChatInput, { type ChatInputHandle } from '../../../components/ui/chat-input';
 import { useChatInput } from '../hooks/useChatInput';
 import { useIsMobile } from '@/hooks/useIsMobile';
 import { MobileFabChat } from '@/components/ui/mobile-fab-chat';
 
-const SUGGESTION_CHIPS: string[] = [
-  "Summarize Apple's earnings",
-  'Compare TSLA vs BYD',
-  'Predict market volatility',
-  'Analyze my portfolio risk',
-];
+// FORK: 추천 prompt 를 i18n 키로 derive — locale 별 종목/시장 컨텍스트 분기
+const SUGGESTION_KEYS = [
+  'dashboard.suggestionEarnings',
+  'dashboard.suggestionCompare',
+  'dashboard.suggestionVolatility',
+  'dashboard.suggestionPortfolio',
+] as const;
 
 /**
  * Floating chat input wrapper for dashboard.
@@ -17,6 +19,11 @@ const SUGGESTION_CHIPS: string[] = [
  * On mobile: collapses to a floating logo FAB by default.
  */
 function ChatInputCard() {
+  const { t } = useTranslation();
+  const suggestionChips = useMemo(
+    () => SUGGESTION_KEYS.map((key) => t(key)),
+    [t],
+  );
   const {
     mode,
     setMode,
@@ -68,7 +75,7 @@ function ChatInputCard() {
       <div className="pointer-events-auto w-full max-w-2xl px-4">
         {/* Suggestion bubbles — above the input, outside focus container */}
         <div className={`dashboard-suggestion-bubbles ${focused ? 'visible' : ''}`}>
-          {SUGGESTION_CHIPS.map((label, i) => (
+          {suggestionChips.map((label, i) => (
             <button
               key={label}
               type="button"

--- a/web/src/pages/Dashboard/components/ChatInputCard.tsx
+++ b/web/src/pages/Dashboard/components/ChatInputCard.tsx
@@ -6,11 +6,12 @@ import { useIsMobile } from '@/hooks/useIsMobile';
 import { MobileFabChat } from '@/components/ui/mobile-fab-chat';
 
 // FORK: 추천 prompt 를 i18n 키로 derive — locale 별 종목/시장 컨텍스트 분기
+// id 는 React key 충돌 방지용 안정 식별자 (label 이 locale 따라 바뀌고 중복될 수 있음).
 const SUGGESTION_KEYS = [
-  'dashboard.suggestionEarnings',
-  'dashboard.suggestionCompare',
-  'dashboard.suggestionVolatility',
-  'dashboard.suggestionPortfolio',
+  { id: 'earnings', key: 'dashboard.suggestionEarnings' },
+  { id: 'compare', key: 'dashboard.suggestionCompare' },
+  { id: 'volatility', key: 'dashboard.suggestionVolatility' },
+  { id: 'portfolio', key: 'dashboard.suggestionPortfolio' },
 ] as const;
 
 /**
@@ -21,7 +22,7 @@ const SUGGESTION_KEYS = [
 function ChatInputCard() {
   const { t } = useTranslation();
   const suggestionChips = useMemo(
-    () => SUGGESTION_KEYS.map((key) => t(key)),
+    () => SUGGESTION_KEYS.map(({ id, key }) => ({ id, label: t(key) })),
     [t],
   );
   const {
@@ -63,7 +64,7 @@ function ChatInputCard() {
             workspaces={workspaces}
             selectedWorkspaceId={selectedWorkspaceId}
             onWorkspaceChange={setSelectedWorkspaceId}
-            placeholder="Ask AI about market trends..."
+            placeholder={t('dashboard.chatPlaceholder')}
           />
         </div>
       </MobileFabChat>
@@ -75,9 +76,9 @@ function ChatInputCard() {
       <div className="pointer-events-auto w-full max-w-2xl px-4">
         {/* Suggestion bubbles — above the input, outside focus container */}
         <div className={`dashboard-suggestion-bubbles ${focused ? 'visible' : ''}`}>
-          {suggestionChips.map((label, i) => (
+          {suggestionChips.map(({ id, label }, i) => (
             <button
-              key={label}
+              key={id}
               type="button"
               className="dashboard-suggestion-bubble"
               style={{ transitionDelay: `${i * 60}ms` }}
@@ -105,7 +106,7 @@ function ChatInputCard() {
             workspaces={workspaces}
             selectedWorkspaceId={selectedWorkspaceId}
             onWorkspaceChange={setSelectedWorkspaceId}
-            placeholder="Ask AI about market trends, specific stocks, or portfolio analysis..."
+            placeholder={t('dashboard.chatPlaceholderFull')}
           />
         </div>
       </div>


### PR DESCRIPTION
## 요약
Closes #24
한국 사용자 첫 인상 한국화의 마지막 한 조각: 온보딩 wizard 한국어 + 대시보드 추천 prompt 의 한국 종목화.

## 변경 사항
- `web/src/pages/Dashboard/components/ChatInputCard.tsx`
  - 하드코딩된 `SUGGESTION_CHIPS` (영어 + 미국 종목 4개) 를 i18n 키로 derive
  - `useTranslation` + `useMemo` 로 locale 변경 시 자동 갱신
  - 키 이름은 국가 중립 (`suggestionEarnings`, `suggestionCompare`, `suggestionVolatility`, `suggestionPortfolio`) — 각 locale 이 자기 시장 컨텍스트로 채움
- `web/src/locales/en-US.json` / `ko-KR.json` / `zh-CN.json`
  - dashboard 섹션에 4개 키 추가
  - en-US: 기존 미국 종목 prompt 유지 (회귀 0)
  - **ko-KR: 한국 시장 prompt**
    - 삼성전자 최근 실적 요약해줘
    - 현대차와 기아 비교 분석
    - 코스피 변동성 전망
    - 내 포트폴리오 리스크 분석
  - zh-CN: 기존 미국 종목의 중국어 번역 (포크 미타깃이라 시장 변경 X)

## 기술적 판단
- **Setup wizard 추가 작업 0**: 6개 step (Method/Provider/Connect/ModelPick/Defaults/Done) 모두 이미 100% i18n 키 사용 (`setup.*`). #22 의 ko-KR.json::setup 섹션이 자동 적용되므로 추가 fix 불필요. spot check 로 검증
- **국가 중립 키 이름**: `suggestion1`/`2`/`3` 같은 인덱스 기반 대신 의미 기반 (Earnings/Compare/Volatility/Portfolio) 으로 → 각 locale 의 시장 컨텍스트가 자연스럽게 들어맞음
- **zh-CN 도 4개 키 채움**: i18n key parity 유지 (en-US 정합) — 회귀 위험 0
- **종목 선정 (ko-KR)**:
  - 삼성전자 = 시가총액 1위 + 사용자 인지도 최고
  - 현대차 vs 기아 = 동종 비교의 대표
  - 코스피 = 시장 전반 변동성
  - 내 포트폴리오 = locale 무관 universal

## 검증
- `cd web && pnpm vitest run` → **526/526 통과**
- `cd web && pnpm lint` 변경 파일 (`ChatInputCard.tsx`, 3 locale json): warning 없음
- 키 정합성 audit (Python 스크립트):
  - en-US.dashboard.suggestion{Earnings,Compare,Volatility,Portfolio} ✓
  - ko-KR.dashboard.suggestion* ✓
  - zh-CN.dashboard.suggestion* ✓


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **다국어 지원 (Localization)**
  * 대시보드 투자 제안 기능이 이제 다국어로 완벽하게 지원됩니다. 영어, 한국어, 중국어 사용자를 위해 각 언어에 최적화된 제안 텍스트가 제공됩니다.
  * 수익, 포트폴리오 비교, 변동성 분석, 포트폴리오 관리와 관련된 새로운 제안 메시지 네 가지가 모든 지원 언어에서 사용 가능합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->