### PR TITLE
feat: 대시보드 인덱스 위젯 한국 시장 분기 (KOSPI/KOSDAQ/KOSPI 200)

### DIFF
--- a/web/src/lib/__tests__/utils.test.ts
+++ b/web/src/lib/__tests__/utils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { cn, utcMsToChartSec, utcMsToETDate, utcMsToETTime } from '../utils';
+import {
+  cn,
+  utcMsToChartSec,
+  utcMsToETDate,
+  utcMsToETTime,
+  utcMsToTzDate,
+  utcMsToTzTime,
+} from '../utils';
 
 describe('cn', () => {
   it('merges simple class names', () => {
@@ -66,5 +73,40 @@ describe('utcMsToETTime', () => {
     const utcMs = Date.UTC(2024, 5, 15, 18, 30, 0); // June 15, 2024 18:30 UTC
     const result = utcMsToETTime(utcMs);
     expect(result).toMatch(/^\d{2}:\d{2}$/);
+  });
+});
+
+describe('utcMsToTzDate', () => {
+  it('returns YYYY-MM-DD in the given timezone (Asia/Seoul)', () => {
+    // 2024-06-15 18:00 UTC → KST 03:00 다음날 (KST = UTC+9)
+    const utcMs = Date.UTC(2024, 5, 15, 18, 0, 0);
+    expect(utcMsToTzDate(utcMs, 'Asia/Seoul')).toBe('2024-06-16');
+  });
+
+  it('matches utcMsToETDate when given America/New_York', () => {
+    const utcMs = Date.UTC(2024, 5, 15, 20, 0, 0);
+    expect(utcMsToTzDate(utcMs, 'America/New_York')).toBe(utcMsToETDate(utcMs));
+  });
+});
+
+describe('utcMsToTzTime', () => {
+  it('returns HH:MM 24h in the given timezone (Asia/Seoul)', () => {
+    // 2024-06-15 03:00 UTC → KST 12:00 (UTC+9, no DST)
+    const utcMs = Date.UTC(2024, 5, 15, 3, 0, 0);
+    expect(utcMsToTzTime(utcMs, 'Asia/Seoul')).toBe('12:00');
+  });
+
+  it('correctly identifies KRX regular hours (KST 09:00-15:30) for a June timestamp', () => {
+    // 2024-06-17 (월) 00:00 UTC = 09:00 KST → 정규장 시작
+    const openMs = Date.UTC(2024, 5, 17, 0, 0, 0);
+    expect(utcMsToTzTime(openMs, 'Asia/Seoul')).toBe('09:00');
+    // 06:30 UTC = 15:30 KST → 정규장 종료
+    const closeMs = Date.UTC(2024, 5, 17, 6, 30, 0);
+    expect(utcMsToTzTime(closeMs, 'Asia/Seoul')).toBe('15:30');
+  });
+
+  it('matches utcMsToETTime when given America/New_York', () => {
+    const utcMs = Date.UTC(2024, 5, 15, 18, 30, 0);
+    expect(utcMsToTzTime(utcMs, 'America/New_York')).toBe(utcMsToETTime(utcMs));
   });
 });

--- a/web/src/lib/utils.ts
+++ b/web/src/lib/utils.ts
@@ -20,15 +20,23 @@ const _etParts = new Intl.DateTimeFormat('en-US', {
   hour12: false,
 });
 
+/** Convert UTC Unix ms to a timezone-local date string (YYYY-MM-DD). */
+export const utcMsToTzDate = (ms: number, timeZone: string): string =>
+  new Date(ms).toLocaleDateString('en-CA', { timeZone });
+
+/** Convert UTC Unix ms to a timezone-local time string (HH:MM, 24h). */
+export const utcMsToTzTime = (ms: number, timeZone: string): string =>
+  new Date(ms).toLocaleTimeString('en-US', {
+    timeZone, hour: '2-digit', minute: '2-digit', hour12: false,
+  });
+
 /** Convert UTC Unix ms to ET date string (YYYY-MM-DD). */
 export const utcMsToETDate = (ms: number): string =>
-  new Date(ms).toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+  utcMsToTzDate(ms, 'America/New_York');
 
 /** Convert UTC Unix ms to ET time string (HH:MM, 24h). */
 export const utcMsToETTime = (ms: number): string =>
-  new Date(ms).toLocaleTimeString('en-US', {
-    timeZone: 'America/New_York', hour: '2-digit', minute: '2-digit', hour12: false,
-  });
+  utcMsToTzTime(ms, 'America/New_York');
 
 export function utcMsToChartSec(utcMs: number | null | undefined): number {
   if (utcMs == null || isNaN(utcMs)) return 0;

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -363,11 +363,13 @@ function IndexMovementCard({ indices = [], loading = false }: IndexMovementCardP
 
   // FORK: locale 별 인덱스 개수 (US=5, KR=3) 에 맞춰 xl 그리드 컬럼 수 동적 결정.
   // Tailwind 가 dynamic class 를 purge 하므로 정적 매핑만 사용.
+  // 스켈레톤 개수도 동일한 colCount 로 정렬 — indices 가 비어있을 때 컬럼 수보다 많은 스켈레톤이 그려지는 것을 방지.
+  const colCount = indices.length >= 5 ? 5 : indices.length === 4 ? 4 : 3;
   const xlColsClass =
-    indices.length >= 5 ? 'xl:grid-cols-5'
-      : indices.length === 4 ? 'xl:grid-cols-4'
+    colCount === 5 ? 'xl:grid-cols-5'
+      : colCount === 4 ? 'xl:grid-cols-4'
         : 'xl:grid-cols-3';
-  const skeletonCount = indices.length || 5;
+  const skeletonCount = colCount;
 
   return (
     <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 ${xlColsClass} gap-4`}>

--- a/web/src/pages/Dashboard/components/IndexMovementCard.tsx
+++ b/web/src/pages/Dashboard/components/IndexMovementCard.tsx
@@ -361,10 +361,18 @@ function IndexMovementCard({ indices = [], loading = false }: IndexMovementCardP
     return <IndexStackWidget indices={indices} />;
   }
 
+  // FORK: locale 별 인덱스 개수 (US=5, KR=3) 에 맞춰 xl 그리드 컬럼 수 동적 결정.
+  // Tailwind 가 dynamic class 를 purge 하므로 정적 매핑만 사용.
+  const xlColsClass =
+    indices.length >= 5 ? 'xl:grid-cols-5'
+      : indices.length === 4 ? 'xl:grid-cols-4'
+        : 'xl:grid-cols-3';
+  const skeletonCount = indices.length || 5;
+
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-5 gap-4">
+    <div className={`grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 ${xlColsClass} gap-4`}>
       {loading ? (
-        <IndexSkeleton count={5} />
+        <IndexSkeleton count={skeletonCount} />
       ) : (
         indices.map((index, i) => (
           <IndexCard key={index.symbol} index={index} delay={i} />

--- a/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
+++ b/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
@@ -8,10 +8,17 @@ vi.mock('../../utils/api', () => ({
   getNews: vi.fn(),
   getIndices: vi.fn(),
   INDEX_SYMBOLS: ['GSPC', 'IXIC', 'DJI', 'RUT', 'VIX'],
+  KR_INDEX_SYMBOLS: ['KS11', 'KQ11', 'KS200'],
   fallbackIndex: vi.fn((s: string) => ({
     symbol: s, name: s, price: 0, change: 0, changePercent: 0, isPositive: true, sparklineData: [],
   })),
   normalizeIndexSymbol: vi.fn((s: string) => String(s).replace(/^\^/, '').toUpperCase()),
+  getIndexSetForLocale: vi.fn((locale?: string | null) => {
+    if (locale && locale.toLowerCase().startsWith('ko')) {
+      return { symbols: ['KS11', 'KQ11', 'KS200'], names: { KS11: '코스피', KQ11: '코스닥', KS200: '코스피 200' } };
+    }
+    return { symbols: ['GSPC', 'IXIC', 'DJI', 'RUT', 'VIX'], names: { GSPC: 'S&P 500', IXIC: 'NASDAQ', DJI: 'Dow Jones', RUT: 'Russell 2000', VIX: 'VIX' } };
+  }),
 }));
 
 vi.mock('@/lib/marketUtils', () => ({

--- a/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
+++ b/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
@@ -2,7 +2,8 @@ import { describe, it, expect, vi, beforeEach } from 'vitest';
 import type { Mock } from 'vitest';
 import { renderHookWithProviders } from '../../../../test/utils';
 import { useDashboardData } from '../useDashboardData';
-import { waitFor } from '@testing-library/react';
+import { act, waitFor } from '@testing-library/react';
+import i18n from '../../../../i18n';
 
 vi.mock('../../utils/api', () => ({
   getNews: vi.fn(),
@@ -33,8 +34,10 @@ const mockGetIndices = getIndices as Mock;
 const mockGetNews = getNews as Mock;
 
 describe('useDashboardData', () => {
-  beforeEach(() => {
+  beforeEach(async () => {
     vi.clearAllMocks();
+    // 다른 테스트로부터의 locale leakage 방지 — 각 테스트가 en-US 에서 시작
+    await i18n.changeLanguage('en-US');
     mockFetchMarketStatus.mockResolvedValue({ market: 'open', afterHours: false, earlyHours: false });
     mockGetIndices.mockResolvedValue({
       indices: [
@@ -102,5 +105,30 @@ describe('useDashboardData', () => {
     await waitFor(() => expect(result.current.marketStatus).not.toBeNull());
     expect(result.current.marketStatusRef).toBeDefined();
     expect(result.current.marketStatusRef.current).toEqual(result.current.marketStatus);
+  });
+
+  it('refetches indices with KR ticker set when locale changes to ko-KR', async () => {
+    // en-US 초기 상태 — getIndices 가 US 심볼로 호출됐는지 확인
+    renderHookWithProviders(() => useDashboardData());
+    await waitFor(() => {
+      expect(mockGetIndices).toHaveBeenCalledWith(['GSPC', 'IXIC', 'DJI', 'RUT', 'VIX']);
+    });
+
+    const usCallCount = mockGetIndices.mock.calls.length;
+
+    // locale 을 ko-KR 로 전환 — useTranslation 구독자가 리렌더 → useMemo dep 변경 → queryKey 갱신 → 자동 refetch
+    await act(async () => {
+      await i18n.changeLanguage('ko-KR');
+    });
+
+    await waitFor(() => {
+      const krCall = mockGetIndices.mock.calls.find((args) =>
+        Array.isArray(args[0]) && args[0][0] === 'KS11',
+      );
+      expect(krCall).toBeDefined();
+      expect(krCall![0]).toEqual(['KS11', 'KQ11', 'KS200']);
+    });
+    // locale 변경 이후에 추가 호출이 발생했는지 확인 — 캐시가 분리되어 새 fetch 가 트리거됨
+    expect(mockGetIndices.mock.calls.length).toBeGreaterThan(usCallCount);
   });
 });

--- a/web/src/pages/Dashboard/hooks/useDashboardData.ts
+++ b/web/src/pages/Dashboard/hooks/useDashboardData.ts
@@ -1,5 +1,13 @@
+import { useMemo } from 'react';
 import { useQuery } from '@tanstack/react-query';
-import { getNews, getIndices, INDEX_SYMBOLS, fallbackIndex, normalizeIndexSymbol } from '../utils/api';
+import { useTranslation } from 'react-i18next';
+import {
+  getNews,
+  getIndices,
+  fallbackIndex,
+  normalizeIndexSymbol,
+  getIndexSetForLocale,
+} from '../utils/api';
 import { fetchMarketStatus } from '@/lib/marketUtils';
 import type { IndexData } from '@/types/market';
 
@@ -54,6 +62,10 @@ function formatRelativeTime(timestamp: string | number | null | undefined): stri
  * Eliminates race conditions and reduces boilerplate of manual useEffects.
  */
 export function useDashboardData(): DashboardData {
+  // FORK: locale-aware 인덱스 set 선택 (ko-KR → KOSPI/KOSDAQ/KOSPI 200/V-KOSPI, 그 외 → US 5종)
+  const { i18n } = useTranslation();
+  const indexSet = useMemo(() => getIndexSetForLocale(i18n.language), [i18n.language]);
+
   // 1. Market Status (Polls every 60s, cached globally)
   const { data: marketStatus = null } = useQuery<MarketStatusData | null>({
     queryKey: ['dashboard', 'marketStatus'],
@@ -68,14 +80,15 @@ export function useDashboardData(): DashboardData {
     (marketStatus && !marketStatus.afterHours && !marketStatus.earlyHours && marketStatus.market !== 'closed');
 
   const { data: indices, isLoading: indicesLoading } = useQuery<IndexData[]>({
-    queryKey: ['dashboard', 'indices', INDEX_SYMBOLS],
+    // queryKey 에 indexSet.symbols 를 포함 → locale 변경 시 자동 refetch + 별도 캐시 분리
+    queryKey: ['dashboard', 'indices', indexSet.symbols],
     queryFn: async () => {
-      const { indices: next } = await getIndices(INDEX_SYMBOLS);
+      const { indices: next } = await getIndices(indexSet.symbols);
       return next;
     },
-    // Using placeholderData provides standard fallback values instantly 
+    // Using placeholderData provides standard fallback values instantly
     // without populating the cache as "fresh", thereby triggering an immediate background fetch
-    placeholderData: (): IndexData[] => INDEX_SYMBOLS.map((s) => fallbackIndex(normalizeIndexSymbol(s))),
+    placeholderData: (): IndexData[] => indexSet.symbols.map((s) => fallbackIndex(normalizeIndexSymbol(s))),
     refetchInterval: isMarketOpen ? 30000 : 60000,
     refetchIntervalInBackground: false,
     staleTime: 10000,

--- a/web/src/pages/Dashboard/hooks/useDashboardData.ts
+++ b/web/src/pages/Dashboard/hooks/useDashboardData.ts
@@ -62,7 +62,7 @@ function formatRelativeTime(timestamp: string | number | null | undefined): stri
  * Eliminates race conditions and reduces boilerplate of manual useEffects.
  */
 export function useDashboardData(): DashboardData {
-  // FORK: locale-aware 인덱스 set 선택 (ko-KR → KOSPI/KOSDAQ/KOSPI 200/V-KOSPI, 그 외 → US 5종)
+  // FORK: locale-aware 인덱스 set 선택 (ko-* → KOSPI/KOSDAQ/KOSPI 200, 그 외 → US 5종)
   const { i18n } = useTranslation();
   const indexSet = useMemo(() => getIndexSetForLocale(i18n.language), [i18n.language]);
 

--- a/web/src/pages/Dashboard/utils/__tests__/api.test.ts
+++ b/web/src/pages/Dashboard/utils/__tests__/api.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getIndexSetForLocale,
+  INDEX_SYMBOLS,
+  KR_INDEX_SYMBOLS,
+  KR_INDEX_NAMES,
+} from '../api';
+
+describe('getIndexSetForLocale', () => {
+  it('returns US set for en-US', () => {
+    const set = getIndexSetForLocale('en-US');
+    expect(set.symbols).toEqual(INDEX_SYMBOLS);
+    expect(set.names.GSPC).toBe('S&P 500');
+  });
+
+  it('returns US set for zh-CN (non-ko locale)', () => {
+    const set = getIndexSetForLocale('zh-CN');
+    expect(set.symbols).toEqual(INDEX_SYMBOLS);
+  });
+
+  it('returns KR set for ko-KR', () => {
+    const set = getIndexSetForLocale('ko-KR');
+    expect(set.symbols).toEqual(KR_INDEX_SYMBOLS);
+    expect(set.names).toEqual(KR_INDEX_NAMES);
+  });
+
+  it('returns KR set for bare "ko"', () => {
+    const set = getIndexSetForLocale('ko');
+    expect(set.symbols).toEqual(KR_INDEX_SYMBOLS);
+  });
+
+  it('is case-insensitive on locale prefix', () => {
+    expect(getIndexSetForLocale('KO-KR').symbols).toEqual(KR_INDEX_SYMBOLS);
+  });
+
+  it('falls back to US set for undefined / null / empty', () => {
+    expect(getIndexSetForLocale(undefined).symbols).toEqual(INDEX_SYMBOLS);
+    expect(getIndexSetForLocale(null).symbols).toEqual(INDEX_SYMBOLS);
+    expect(getIndexSetForLocale('').symbols).toEqual(INDEX_SYMBOLS);
+  });
+
+  it('KR set covers KOSPI / KOSDAQ / KOSPI 200', () => {
+    expect(KR_INDEX_SYMBOLS).toEqual(['KS11', 'KQ11', 'KS200']);
+    expect(KR_INDEX_NAMES.KS11).toBe('코스피');
+    expect(KR_INDEX_NAMES.KQ11).toBe('코스닥');
+    expect(KR_INDEX_NAMES.KS200).toBe('코스피 200');
+  });
+});

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -146,10 +146,17 @@ function normalizeIndexSymbol(s: string): string {
   return String(s).replace(/^\^/, '').toUpperCase();
 }
 
+/**
+ * 정규화된 심볼의 표시명 도출. US set → KR set → 호출자 fallback (예: snapshot.name) → 심볼 자체 순서로 resolve.
+ */
+function getIndexDisplayName(norm: string, fallback?: string | null): string {
+  return INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? fallback ?? norm;
+}
+
 function fallbackIndex(norm: string): IndexData {
   return {
     symbol: norm,
-    name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? norm,
+    name: getIndexDisplayName(norm),
     price: 0,
     change: 0,
     changePercent: 0,
@@ -197,7 +204,7 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
 
     const result: IndexData = {
       symbol: norm,
-      name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? norm,
+      name: getIndexDisplayName(norm),
       price: Math.round(close * 100) / 100,
       change: Math.round(change * 100) / 100,
       changePercent: Math.round(changePercent * 100) / 100,
@@ -250,7 +257,7 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
       const changePct = snap.change_percent ?? (snap.previous_close ? ((change / snap.previous_close) * 100) : 0);
       return {
         symbol: norm,
-        name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? snap.name ?? norm,
+        name: getIndexDisplayName(norm, snap.name),
         price: Math.round(snap.price * 100) / 100,
         change: Math.round(change * 100) / 100,
         changePercent: Math.round(changePct * 100) / 100,

--- a/web/src/pages/Dashboard/utils/api.ts
+++ b/web/src/pages/Dashboard/utils/api.ts
@@ -3,7 +3,7 @@
  * All backend endpoints used by the Dashboard page
  */
 import { api } from '@/api/client';
-import { utcMsToETDate, utcMsToETTime } from '@/lib/utils';
+import { utcMsToTzDate, utcMsToTzTime } from '@/lib/utils';
 import * as portfolioApi from './portfolio';
 import * as watchlistApi from './watchlist';
 import * as watchlistItemsApi from './watchlistItems';
@@ -104,6 +104,44 @@ interface InfoFlowResponse {
 const INDEX_SYMBOLS: string[] = ['GSPC', 'IXIC', 'DJI', 'RUT', 'VIX'];
 const INDEX_NAMES: Record<string, string> = { GSPC: 'S&P 500', IXIC: 'NASDAQ', DJI: 'Dow Jones', RUT: 'Russell 2000', VIX: 'VIX' };
 
+// FORK: 한국 시장 인덱스 set — yfinance ^KS11/^KQ11/^KS200 로 자동 prefix 됨.
+// 백엔드 yfinance source 가 indices asset_type 일 때 ^ prefix 를 자동 추가하므로 여기서는 bare 심볼만 둠.
+// V-KOSPI(^VKOSPI) 는 yfinance 내부 PriceHistory 버그로 현재 fetch 불가 — 별도 데이터 소스 도입 후 추가 예정.
+const KR_INDEX_SYMBOLS: string[] = ['KS11', 'KQ11', 'KS200'];
+const KR_INDEX_NAMES: Record<string, string> = {
+  KS11: '코스피',
+  KQ11: '코스닥',
+  KS200: '코스피 200',
+};
+
+const _KR_INDEX_SET = new Set(KR_INDEX_SYMBOLS);
+
+/**
+ * 정규화된 심볼 기반으로 거래소 시간대를 도출. locale 에 의존하지 않음 —
+ * 심볼이 KR set 에 속하면 KST, 아니면 ET (NYSE/NASDAQ).
+ */
+function getIndexTimezone(norm: string): string {
+  return _KR_INDEX_SET.has(norm) ? 'Asia/Seoul' : 'America/New_York';
+}
+
+/** 정규장 시간 (HH:MM 24h, 거래소 로컬). KRX 09:00-15:30, NYSE/NASDAQ 09:30-16:00. */
+function getIndexMarketHours(norm: string): { open: string; close: string } {
+  return _KR_INDEX_SET.has(norm)
+    ? { open: '09:00', close: '15:30' }
+    : { open: '09:30', close: '16:00' };
+}
+
+/**
+ * locale 에 맞는 인덱스 ticker set + 표시명 반환.
+ * ko 로 시작하는 locale → KR set, 그 외 → US set.
+ */
+export function getIndexSetForLocale(locale: string | undefined | null): { symbols: string[]; names: Record<string, string> } {
+  if (locale && locale.toLowerCase().startsWith('ko')) {
+    return { symbols: KR_INDEX_SYMBOLS, names: KR_INDEX_NAMES };
+  }
+  return { symbols: INDEX_SYMBOLS, names: INDEX_NAMES };
+}
+
 function normalizeIndexSymbol(s: string): string {
   return String(s).replace(/^\^/, '').toUpperCase();
 }
@@ -111,7 +149,7 @@ function normalizeIndexSymbol(s: string): string {
 function fallbackIndex(norm: string): IndexData {
   return {
     symbol: norm,
-    name: INDEX_NAMES[norm] ?? norm,
+    name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? norm,
     price: 0,
     change: 0,
     changePercent: 0,
@@ -139,12 +177,14 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
     // Sort ascending by time (Unix ms)
     const sorted = [...pts].sort((a: IntradayPoint, b: IntradayPoint) => a.time - b.time);
 
-    // Isolate the most recent trading day, regular hours only (9:30–16:00)
-    const latestDate = utcMsToETDate(sorted[sorted.length - 1].time);
+    // FORK: 심볼별 거래소 시간대로 정규장 시간 필터링 (KR: KST 09:00-15:30, US: ET 09:30-16:00).
+    const tz = getIndexTimezone(norm);
+    const hours = getIndexMarketHours(norm);
+    const latestDate = utcMsToTzDate(sorted[sorted.length - 1].time, tz);
     const todayPoints = sorted.filter((p: IntradayPoint) => {
-      if (utcMsToETDate(p.time) !== latestDate) return false;
-      const t = utcMsToETTime(p.time);
-      return t >= '09:30' && t <= '16:00';
+      if (utcMsToTzDate(p.time, tz) !== latestDate) return false;
+      const t = utcMsToTzTime(p.time, tz);
+      return t >= hours.open && t <= hours.close;
     });
 
     const oldest = todayPoints[0];
@@ -157,14 +197,14 @@ export async function getIndex(symbol: string, _opts: Record<string, unknown> = 
 
     const result: IndexData = {
       symbol: norm,
-      name: INDEX_NAMES[norm] ?? norm,
+      name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? norm,
       price: Math.round(close * 100) / 100,
       change: Math.round(change * 100) / 100,
       changePercent: Math.round(changePercent * 100) / 100,
       isPositive: change >= 0,
       sparklineData: todayPoints
         .filter((p: IntradayPoint) => Number(p.close) > 0)
-        .map((p: IntradayPoint) => ({ time: utcMsToETTime(p.time), val: Number(p.close) })),
+        .map((p: IntradayPoint) => ({ time: utcMsToTzTime(p.time, tz), val: Number(p.close) })),
     };
 
     return result;
@@ -210,7 +250,7 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
       const changePct = snap.change_percent ?? (snap.previous_close ? ((change / snap.previous_close) * 100) : 0);
       return {
         symbol: norm,
-        name: INDEX_NAMES[norm] ?? snap.name ?? norm,
+        name: INDEX_NAMES[norm] ?? KR_INDEX_NAMES[norm] ?? snap.name ?? norm,
         price: Math.round(snap.price * 100) / 100,
         change: Math.round(change * 100) / 100,
         changePercent: Math.round(changePct * 100) / 100,
@@ -226,7 +266,14 @@ export async function getIndices(symbols: string[] = INDEX_SYMBOLS, _opts: Recor
   return { indices, failedCount };
 }
 
-export { INDEX_NAMES, INDEX_SYMBOLS, fallbackIndex, normalizeIndexSymbol };
+export {
+  INDEX_NAMES,
+  INDEX_SYMBOLS,
+  KR_INDEX_NAMES,
+  KR_INDEX_SYMBOLS,
+  fallbackIndex,
+  normalizeIndexSymbol,
+};
 
 // --- Hello ---
 


### PR DESCRIPTION
## 요약
Refs #23 (인덱스 부분; 한국 뉴스는 #27 로 분리)
ko-KR locale 사용자에게 미국 인덱스 5종(S&P 500/NASDAQ/Dow/Russell 2000/VIX) 대신 한국 인덱스 3종(KOSPI/KOSDAQ/KOSPI 200) 카드를 노출. yfinance 가 \`KS11\`→\`^KS11\` 로 자동 prefix 하므로 백엔드 변경 없이 frontend 만으로 처리.

## 변경 사항
- `web/src/pages/Dashboard/utils/api.ts`
  - `KR_INDEX_SYMBOLS` / `KR_INDEX_NAMES` (KS11/KQ11/KS200) 추가
  - `getIndexSetForLocale(locale)`: ko-* → KR set, 그 외 → 기존 US set
  - `getIndex` 가 심볼로 거래소 시간대 자동 도출 (KR=Asia/Seoul, US=America/New_York)
  - sparkline 정규장 필터를 KRX 09:00-15:30 vs NYSE 09:30-16:00 로 분기
- `web/src/lib/utils.ts`
  - `utcMsToTzDate` / `utcMsToTzTime` 범용 헬퍼 추출, 기존 ET wrapper 호환 유지
- `web/src/pages/Dashboard/hooks/useDashboardData.ts`
  - `useTranslation().i18n.language` 로 locale 감지 → indexSet 동적 선택
  - queryKey 에 symbols 포함 → locale 변경 시 자동 refetch + 캐시 분리
- `web/src/pages/Dashboard/components/IndexMovementCard.tsx`
  - xl 그리드 컬럼 수를 \`indices.length\` 기반 정적 매핑 (3/4/5)
- 테스트 신규: `web/src/pages/Dashboard/utils/__tests__/api.test.ts` — `getIndexSetForLocale` 분기 7케이스
- 테스트 보강: `web/src/lib/__tests__/utils.test.ts` — `utcMsToTz*` KST 케이스 4개 추가
- 테스트 갱신: `useDashboardData.test.tsx` mock 에 `getIndexSetForLocale` / `KR_INDEX_SYMBOLS` 추가

## 기술적 판단
**Issue 본문의 4개 체크박스 중 인덱스만 처리, 뉴스는 #27 로 분리한 이유**:
- 인덱스: frontend-only + yfinance 자동 fallback 으로 깔끔. 단 ET 09:30-16:00 으로 sparkline 을 필터링하던 기존 로직은 KR 인덱스에서 빈 차트가 그려지던 잠재 버그였고, 이번에 심볼별 거래소 시간대 도출로 함께 해결.
- 뉴스: yfinance 에 한국 ticker hint 만 던지면 영문 Bloomberg/Reuters 결과 → \"한국화 됐다\" 는 misleading 시그널. 별도 `KoreanNewsSource` (네이버 금융 RSS 등) 가 필요하므로 #27 로 추적.

**V-KOSPI 제외 이유**: yfinance `^VKOSPI` 가 `AttributeError: 'PriceHistory' object has no attribute '_dividends'` 로 fetch 실패 (yfinance 내부 버그). 같은 라이브러리 내 다른 KR 대안(`KRX100`, `KOSDAQ150` 등)도 동일 증상. KRX 직접 또는 별도 데이터 소스 도입 후 재추가 예정 — 이슈 본문에 명시한 `V-KOSPI` 항목은 인프라 한계로 deferred.

**locale 신호 선택**: `i18n.language` (UI state) vs `user.locale` (서버 영속). Settings 변경 시 두 값이 동기화되므로 UI 즉시 반응성을 위해 `i18n.language` 사용.

**Grid 동적 컬럼**: Tailwind purge 가 동적 className 을 제거하므로 `length >= 5 / === 4 / else` 정적 매핑.

## 검증
- `pnpm vitest run`: 538/538 passed (기존 526 + 신규 12)
- `pnpm lint`: 0 errors / 52 warnings (모두 기존 MarketView 관련, 본 변경 무관)
- 백엔드 yfinance 직접 호출 smoke test: `^KS11` 6475.63 / `^KQ11` 1203.84 / `^KS200` 971.87 정상 응답 확인
- locale parity: en-US/ko-KR/zh-CN 키 변경 없음 (이번 PR 은 i18n json 미수정)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새 기능**
  * 한국 시장 지수(KS11, KQ11, KS200) 지원 추가
  * 사용자 언어 설정에 따른 자동 시장 지수 변경
  * 향상된 시간대 기반 날짜 및 시간 표시 형식

* **개선**
  * 대시보드 그리드 레이아웃을 지수 개수에 맞게 동적 조정

<!-- end of auto-generated comment: release notes by coderabbit.ai -->