### PR TITLE
fix: KoreanDataSource.get_snapshots asset_type 가드 (KR 인덱스 backend 빈 응답)

### DIFF
--- a/src/data_client/korean/data_source.py
+++ b/src/data_client/korean/data_source.py
@@ -171,6 +171,14 @@ class KoreanDataSource:
         asset_type: str = "stocks",
         user_id: str | None = None,
     ) -> list[dict[str, Any]]:
+        # FORK: pykrx 는 KOSPI/KOSDAQ 주식 snapshot 만 지원. 인덱스(KS11/KQ11/...) 는 미지원.
+        # 빈 list 반환 시 MarketDataProvider 가 "성공한 결과" 로 인식해 yfinance 로 fallback 안 됨 →
+        # NotImplementedError 를 raise 해 chain 의 다음 source 로 넘기도록 함 (get_intraday 와 동일 패턴).
+        if asset_type != "stocks":
+            raise NotImplementedError(
+                f"KoreanDataSource only supports stock snapshots, got asset_type={asset_type!r}"
+            )
+
         if not symbols:
             return []
 

--- a/src/data_client/korean/data_source.py
+++ b/src/data_client/korean/data_source.py
@@ -1,7 +1,13 @@
 """MarketDataSource implementation backed by pykrx.
 
-Provides KOSPI/KOSDAQ daily OHLCV data. Intraday intervals are not
-supported — raises ValueError so the chain falls back to the next source.
+Provides KOSPI/KOSDAQ daily OHLCV data and stock snapshots only.
+
+Unsupported requests raise to trigger ``MarketDataProvider`` fallback to the
+next source in the chain (silent empty results would be mistaken for success):
+- Intraday intervals → ``ValueError`` (pykrx is daily-only).
+- ``get_snapshots`` with ``asset_type != "stocks"`` (e.g. ``"indices"``) →
+  ``NotImplementedError`` (pykrx exposes index OHLCV via a separate API not
+  wired up here; index snapshots route to yfinance instead).
 
 Symbols are expected in Yahoo-style format (e.g. ``005930.KS`` for KOSPI,
 ``263750.KQ`` for KOSDAQ). The ``.KS``/``.KQ`` suffix is stripped before

--- a/tests/unit/data_client/korean/test_data_source.py
+++ b/tests/unit/data_client/korean/test_data_source.py
@@ -263,3 +263,22 @@ class TestGetSnapshots:
         result = await source.get_snapshots(["005930.KS"])
 
         assert result == []
+
+    @pytest.mark.asyncio
+    @patch("src.data_client.korean.data_source.stock")
+    async def test_indices_asset_type_raises_to_trigger_chain_fallback(
+        self, mock_stock, source
+    ):
+        # KoreanDataSource 는 인덱스 snapshot 을 지원하지 않음. 빈 list 를 반환하면
+        # MarketDataProvider 가 yfinance 로 fallback 하지 않으므로 명시적으로 raise.
+        with pytest.raises(NotImplementedError, match="indices"):
+            await source.get_snapshots(["KS11", "KQ11"], asset_type="indices")
+        # pykrx 는 호출되지 않아야 함 (가드가 먼저 작동)
+        mock_stock.get_market_ohlcv.assert_not_called()
+
+    @pytest.mark.asyncio
+    @patch("src.data_client.korean.data_source.stock")
+    async def test_unknown_asset_type_raises(self, mock_stock, source):
+        with pytest.raises(NotImplementedError):
+            await source.get_snapshots(["X"], asset_type="forex")
+        mock_stock.get_market_ohlcv.assert_not_called()


### PR DESCRIPTION
## 요약
Closes #30
PR #28 머지 후 ko-KR 모드 대시보드에서 KOSPI/KOSDAQ/KOSPI 200 카드가 가격 0 으로 표시되던 backend 버그 수정. PR #28 의 frontend 분기는 옳았으나 backend chain 이 빈 응답으로 silent fail 하던 빈틈을 막음.

## 변경 사항
- `src/data_client/korean/data_source.py`: `get_snapshots` 진입부에 `asset_type != "stocks"` 가드 추가 → `NotImplementedError` raise
- `tests/unit/data_client/korean/test_data_source.py`: 신규 케이스 2개
  - `test_indices_asset_type_raises_to_trigger_chain_fallback`: indices 호출 시 raise + pykrx 미호출 검증
  - `test_unknown_asset_type_raises`: 그 외 asset_type (예: forex) 도 raise

## 기술적 판단
**왜 raise 인가**
`MarketDataProvider.get_snapshots` (src/data_client/market_data_provider.py:216-238) 는 `for entry in self.entries` 로 순차 시도하고 첫 번째 성공한 결과를 그대로 `return` 함. 빈 list 도 "성공" 으로 인식하므로 fallback 트리거 안 됨. `NotImplementedError` 를 raise 해야 chain 이 catch → 다음 entry (yfinance) 시도.

**왜 `get_intraday` 와 같은 ValueError 가 아닌 `NotImplementedError` 인가**
`get_intraday` 는 "interval 미지원" 을 표현하므로 ValueError 가 자연스러움. 여기서는 "이 source 가 indices asset_type 자체를 처리 못 함" 이라는 의미라 `NotImplementedError` 가 더 정확. chain 의 `except Exception` 은 둘 다 catch 하므로 fallback 동작 동일.

**왜 빈 list 반환을 fallback 트리거로 만들지 않았나**
`MarketDataProvider.get_snapshots` 자체를 "빈 list = 다음 시도" 로 바꾸는 옵션도 있지만, 정상 시나리오 (예: 주말에 가격 데이터 0건) 와 구분이 안 됨. source 가 명시적으로 raise 하는 패턴이 의도가 더 분명.

## 검증
- `uv run pytest tests/unit/data_client/korean/test_data_source.py -v`: 21/21 passed (신규 +2)
- `uv run ruff check` (변경 파일): All checks passed
- Live smoke (uv run python provider 직접 호출):
  ```
  market_data.snapshot.fallback | source=korean error=KoreanDataSource only supports stock snapshots, got asset_type='indices'
  snapshots: 3
    ^KS11   6475.6299  (-0.0028%)
    ^KQ11   1203.84    ( 2.5147%)
    ^KS200  971.87     (-0.3844%)
  ```
- Live API (uvicorn `--reload` 자동 반영):
  ```
  curl /api/v1/market-data/snapshots/indexes?symbols=KS11,KQ11,KS200
  → count=3, prices 정상
  ```

## 회귀 영향 범위
- `asset_type='stocks'` 기존 동작 무변화 (fast-path 가드만 추가, 본문 로직 동일)
- 기타 KoreanDataSource 메서드 (`get_intraday`, `get_daily`, `get_market_status`) 변경 없음

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 지원되지 않는 자산 유형(예: 지수, 외환)에 대한 요청이 이제 명시적으로 거부되어 적절한 오류가 발생합니다. 이전에는 침묵적으로 처리되었습니다.

* **테스트**
  * 지원되지 않는 자산 유형에 대한 거부 동작을 검증하는 새로운 단위 테스트가 추가되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->