### PR TITLE
fix: claude-haiku-4-5 thinking.budget_tokens 추가 (#35)

### DIFF
--- a/src/llms/manifest/models.json
+++ b/src/llms/manifest/models.json
@@ -98,7 +98,8 @@
     "parameters": {
       "max_tokens": 64000,
       "thinking": {
-        "type": "enabled"
+        "type": "enabled",
+        "budget_tokens": 8000
       }
     }
   },

--- a/tests/unit/llms/test_manifest_integrity.py
+++ b/tests/unit/llms/test_manifest_integrity.py
@@ -97,3 +97,33 @@ class TestManifestIntegrity:
                 assert "text" in modalities, (
                     f"{model_name}: input_modalities missing 'text': {modalities}"
                 )
+
+    def test_anthropic_thinking_enabled_requires_budget_tokens(self, model_config):
+        """Anthropic SDK 는 thinking.type == 'enabled' 일 때 budget_tokens 필수.
+        누락 시 런타임에 400 (Field required) 으로 실패. 회귀 트리거: issue #35
+        에서 claude-haiku-4-5 가 OAuth variant 와 달리 budget_tokens 누락된 채
+        머지돼 InsightService 가 매 사이클 400 fail. 본 테스트는 anthropic /
+        claude-oauth provider 만 검증 (다른 provider 는 'thinking' 키 의미가
+        다를 수 있음).
+        """
+        ANTHROPIC_PROVIDERS = {"anthropic", "claude-oauth"}
+        failures: list[str] = []
+
+        for model_name, model_def in model_config.llm_config.items():
+            if model_def.get("provider") not in ANTHROPIC_PROVIDERS:
+                continue
+            thinking = model_def.get("parameters", {}).get("thinking")
+            if not isinstance(thinking, dict):
+                continue
+            if thinking.get("type") != "enabled":
+                continue  # adaptive / disabled 는 budget_tokens 불필요
+            if "budget_tokens" not in thinking:
+                failures.append(
+                    f"{model_name}: thinking.type='enabled' 인데 budget_tokens 누락 "
+                    f"({thinking!r})"
+                )
+
+        assert not failures, (
+            f"{len(failures)} 개 Anthropic 모델이 thinking.budget_tokens 누락:\n"
+            + "\n".join(f"  - {f}" for f in failures)
+        )


### PR DESCRIPTION
## 요약
Closes #35
`InsightService` background job 이 Anthropic 400 (`thinking.enabled.budget_tokens: Field required`) 으로 매 pre/post_market 사이클 fail 하던 문제를 수정.

## 변경 사항
- `src/llms/manifest/models.json`: `claude-haiku-4-5` 의 `thinking` 에 `budget_tokens: 8000` 추가 (OAuth variant 와 동일 값)
- `tests/unit/llms/test_manifest_integrity.py`: `test_anthropic_thinking_enabled_requires_budget_tokens` 회귀 테스트 추가

## 기술적 판단
- **scope를 좁힌 이유**: `models.json` 에 `thinking: {type: enabled}` 만 있는 entry 가 14개 더 있지만 (doubao/glm/minimax/kimi 등) 모두 별도 provider 라 SDK 스키마가 다름. 본 issue 는 Anthropic API 만 영향이고 OAuth variant 가 이미 정상이라 minimum diff.
- **회귀 테스트 scope**: `anthropic` / `claude-oauth` provider 만 검증. 다른 provider 가 `thinking` 키를 다른 의미로 쓸 수 있음.

## 검증
- `uv run pytest tests/unit/llms/test_manifest_integrity.py -v` → 4/4 통과
- `uv run python -c "from src.llms import create_llm; llm = create_llm('claude-haiku-4-5'); print(llm.thinking)"` → `{'type': 'enabled', 'budget_tokens': 8000}` 출력

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **테스트**
  * Anthropic 스타일 모델 설정 검증을 위한 새로운 회귀 테스트 추가

* **개선 사항**
  * Claude Haiku 4.5 모델의 사고 토큰 예산 설정 업데이트 (8000 토큰 할당)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->