### PR TITLE
feat: marketStatus 가 region 별로 응답하도록 분리 (#37)

### DIFF
--- a/src/data_client/base.py
+++ b/src/data_client/base.py
@@ -75,8 +75,13 @@ class MarketDataSource(Protocol):
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
-        """Return current market status."""
+        """Return current market status. ``region`` 이 명시되면 source 는 자기가
+        지원하지 않는 region 일 때 ``NotImplementedError`` 를 raise — Provider
+        는 chain 의 다음 candidate 로 fallback. ``region=None`` 은 backward-compat
+        으로 source 의 기본 (자기 default region) status 반환.
+        """
         ...
 
     async def close(self) -> None:

--- a/src/data_client/base.py
+++ b/src/data_client/base.py
@@ -25,6 +25,25 @@ class FetchResult:
     truncated: bool = False
 
 
+def require_region(
+    region: str | None,
+    supported: str,
+    source_name: str,
+) -> None:
+    """Raise ``NotImplementedError`` if ``region`` is set and doesn't match ``supported``.
+
+    Centralizes the region-guard pattern used across ``get_market_status`` of
+    Korean / Yfinance / FMP / GinlixData sources. Each source covers exactly
+    one region for market_status; mismatched calls signal MarketDataProvider
+    to fall back to the next candidate. ``source_name`` should be the qualified
+    method name (e.g. ``"KoreanDataSource.get_market_status"``) for clear logs.
+    """
+    if region is not None and region != supported:
+        raise NotImplementedError(
+            f"{source_name} only supports region={supported!r}, got {region!r}"
+        )
+
+
 class MarketDataSource(Protocol):
     """Unified interface for OHLCV price data fetching."""
 

--- a/src/data_client/fmp/data_source.py
+++ b/src/data_client/fmp/data_source.py
@@ -121,8 +121,16 @@ class FMPDataSource:
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
-        """Derive market status from current time (FMP has no dedicated endpoint)."""
+        """Derive market status from current time (FMP has no dedicated endpoint).
+
+        FORK (#37): NYSE 시간 기반이라 region='us' 또는 None 에만 응답.
+        """
+        if region is not None and region != "us":
+            raise NotImplementedError(
+                f"FMPDataSource market_status only supports region='us', got {region!r}"
+            )
         from src.utils.market_hours import current_market_phase
 
         phase = current_market_phase()

--- a/src/data_client/fmp/data_source.py
+++ b/src/data_client/fmp/data_source.py
@@ -127,10 +127,8 @@ class FMPDataSource:
 
         FORK (#37): NYSE 시간 기반이라 region='us' 또는 None 에만 응답.
         """
-        if region is not None and region != "us":
-            raise NotImplementedError(
-                f"FMPDataSource market_status only supports region='us', got {region!r}"
-            )
+        from src.data_client.base import require_region
+        require_region(region, "us", "FMPDataSource.get_market_status")
         from src.utils.market_hours import current_market_phase
 
         phase = current_market_phase()

--- a/src/data_client/ginlix_data/data_source.py
+++ b/src/data_client/ginlix_data/data_source.py
@@ -194,8 +194,16 @@ class GinlixDataSource:
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch current market status from ginlix-data."""
+        """Fetch current market status from ginlix-data.
+
+        FORK (#37): ginlix-data 는 US 시장만 다루므로 region='us' 또는 None 만 응답.
+        """
+        if region is not None and region != "us":
+            raise NotImplementedError(
+                f"GinlixDataSource market_status only supports region='us', got {region!r}"
+            )
         return await self.client.get_market_status(user_id=user_id)
 
     @staticmethod

--- a/src/data_client/ginlix_data/data_source.py
+++ b/src/data_client/ginlix_data/data_source.py
@@ -200,10 +200,8 @@ class GinlixDataSource:
 
         FORK (#37): ginlix-data 는 US 시장만 다루므로 region='us' 또는 None 만 응답.
         """
-        if region is not None and region != "us":
-            raise NotImplementedError(
-                f"GinlixDataSource market_status only supports region='us', got {region!r}"
-            )
+        from src.data_client.base import require_region
+        require_region(region, "us", "GinlixDataSource.get_market_status")
         return await self.client.get_market_status(user_id=user_id)
 
     @staticmethod

--- a/src/data_client/korean/data_source.py
+++ b/src/data_client/korean/data_source.py
@@ -201,7 +201,14 @@ class KoreanDataSource:
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
+        # FORK (#37): KR 만 지원. region 명시 시 'kr' 외에는 chain 의 다음 source 로
+        # fallback 하도록 NotImplementedError. region=None 은 KR 으로 응답 (기본 동작).
+        if region is not None and region != "kr":
+            raise NotImplementedError(
+                f"KoreanDataSource only supports region='kr', got {region!r}"
+            )
         now = datetime.now(_KST)
         hour = now.hour
         minute = now.minute

--- a/src/data_client/korean/data_source.py
+++ b/src/data_client/korean/data_source.py
@@ -205,10 +205,8 @@ class KoreanDataSource:
     ) -> dict[str, Any]:
         # FORK (#37): KR 만 지원. region 명시 시 'kr' 외에는 chain 의 다음 source 로
         # fallback 하도록 NotImplementedError. region=None 은 KR 으로 응답 (기본 동작).
-        if region is not None and region != "kr":
-            raise NotImplementedError(
-                f"KoreanDataSource only supports region='kr', got {region!r}"
-            )
+        from src.data_client.base import require_region
+        require_region(region, "kr", "KoreanDataSource.get_market_status")
         now = datetime.now(_KST)
         hour = now.hour
         minute = now.minute

--- a/src/data_client/market_data_provider.py
+++ b/src/data_client/market_data_provider.py
@@ -240,24 +240,50 @@ class MarketDataProvider:
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
-        """Fetch market status, trying providers in order."""
+        """Fetch market status, optionally scoped to a region.
+
+        FORK (#37): region 명시 시 markets 에 region 포함된 source 우선 + 'all'
+        source 도 후보 (chain 순서 유지). 각 source 는 자기가 region 을 지원하지
+        않으면 ``NotImplementedError`` 를 raise — 자연스럽게 다음 candidate 로
+        fallback. 'all' 마킹된 source (fmp/yfinance) 도 실제로는 NYSE 시간만 알아서
+        region='kr' 호출 시 NotImplementedError 로 거절하고 KoreanDataSource 로 흘러감.
+        region=None 은 기존 동작 유지 (chain 순서대로 첫 성공 응답).
+        """
+        if region:
+            candidates = [
+                e for e in self.entries
+                if region in e.markets or "all" in e.markets
+            ]
+        else:
+            candidates = list(self.entries)
+
         last_exc: Exception | None = None
-        for entry in self.entries:
+        for entry in candidates:
             fn = getattr(entry.source, "get_market_status", None)
             if fn is None:
                 continue
             try:
-                return await fn(user_id=user_id)
+                return await fn(user_id=user_id, region=region)
+            except NotImplementedError as exc:
+                # source 가 region 을 지원 안 함 — 정상적인 fallback 신호. 로그 noise 줄이기 위해 debug.
+                logger.debug(
+                    "market_data.market_status.skip | source=%s region=%s reason=%s",
+                    entry.name, region, exc,
+                )
+                last_exc = exc
             except Exception as exc:
                 logger.warning(
-                    "market_data.market_status.fallback | source=%s error=%s",
-                    entry.name, exc,
+                    "market_data.market_status.fallback | source=%s region=%s error=%s",
+                    entry.name, region, exc,
                 )
                 last_exc = exc
         if last_exc:
             raise last_exc
-        raise RuntimeError("No data source supports get_market_status")
+        raise RuntimeError(
+            f"No data source supports get_market_status for region={region!r}"
+        )
 
     async def close(self) -> None:
         """Close all underlying sources, catching errors independently."""

--- a/src/data_client/yfinance/data_source.py
+++ b/src/data_client/yfinance/data_source.py
@@ -166,7 +166,14 @@ class YFinanceDataSource:
     async def get_market_status(
         self,
         user_id: str | None = None,
+        region: str | None = None,
     ) -> dict[str, Any]:
+        # FORK (#37): yfinance 는 NYSE 시간 기반이라 region='us' 또는 None 에만 응답.
+        # region='kr' 같은 다른 시장 요청은 잘못된 (US 시간) 정보를 줄 수 있어 거부.
+        if region is not None and region != "us":
+            raise NotImplementedError(
+                f"YfinanceDataSource market_status only supports region='us', got {region!r}"
+            )
         from src.utils.market_hours import current_market_phase
 
         phase = current_market_phase()

--- a/src/data_client/yfinance/data_source.py
+++ b/src/data_client/yfinance/data_source.py
@@ -170,10 +170,8 @@ class YFinanceDataSource:
     ) -> dict[str, Any]:
         # FORK (#37): yfinance 는 NYSE 시간 기반이라 region='us' 또는 None 에만 응답.
         # region='kr' 같은 다른 시장 요청은 잘못된 (US 시간) 정보를 줄 수 있어 거부.
-        if region is not None and region != "us":
-            raise NotImplementedError(
-                f"YfinanceDataSource market_status only supports region='us', got {region!r}"
-            )
+        from src.data_client.base import require_region
+        require_region(region, "us", "YFinanceDataSource.get_market_status")
         from src.utils.market_hours import current_market_phase
 
         phase = current_market_phase()

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -729,9 +729,16 @@ async def get_single_stock_snapshot(symbol: str, user_id: CurrentUserId) -> Snap
     summary="Get current market status (alias)",
     description="Alias for /market-status for backward compatibility.",
 )
-async def get_market_status_alias(user_id: CurrentUserId) -> MarketStatusResponse:
+async def get_market_status_alias(
+    user_id: CurrentUserId,
+    region: Optional[str] = Query(
+        None,
+        description="Market region (e.g. 'us', 'kr'). Defaults to 'us' if omitted.",
+        pattern=r"^[a-z]{2}$",
+    ),
+) -> MarketStatusResponse:
     """Alias for get_market_status."""
-    return await get_market_status(user_id)
+    return await get_market_status(user_id, region)
 
 
 @router.get(
@@ -740,21 +747,33 @@ async def get_market_status_alias(user_id: CurrentUserId) -> MarketStatusRespons
     summary="Get current market status",
     description="Retrieve the current market status (open, closed, extended hours).",
 )
-async def get_market_status(user_id: CurrentUserId) -> MarketStatusResponse:
-    """Get current market status."""
+async def get_market_status(
+    user_id: CurrentUserId,
+    region: Optional[str] = Query(
+        None,
+        description="Market region (e.g. 'us', 'kr'). Defaults to 'us' if omitted.",
+        pattern=r"^[a-z]{2}$",
+    ),
+) -> MarketStatusResponse:
+    """Get current market status. FORK (#37): region 별 분리 — KR/US 사용자가
+    각자 자기 시장 상태를 보도록. region 미지정 시 'us' (backward-compat).
+    """
     try:
         from src.utils.cache.redis_cache import get_cache_client
         from src.data_client import get_market_data_provider
 
+        effective_region = region or "us"
+
         cache = get_cache_client()
-        cache_key = "market:status"
+        # FORK (#37): cache key 에 region 포함 — KR/US status 가 동시에 캐시되도록.
+        cache_key = f"market:status:{effective_region}"
 
         cached = await cache.get(cache_key)
         if cached is not None:
             return MarketStatusResponse(**cached)
 
         provider = await get_market_data_provider()
-        raw = await provider.get_market_status(user_id=user_id)
+        raw = await provider.get_market_status(user_id=user_id, region=effective_region)
 
         response = MarketStatusResponse(
             market=raw.get("market"),

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -790,5 +790,9 @@ async def get_market_status(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error fetching market status: {e}")
+        # FORK (#37): region 을 로그에 포함 — KR/US 사용자별 실패 attribution.
+        logger.error(
+            f"Error fetching market status (region={effective_region!r}, "
+            f"raw_region={region!r}): {e}"
+        )
         raise HTTPException(status_code=500, detail=str(e))

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -219,6 +219,103 @@ class TestMarketDataProvider:
 
 
 # ---------------------------------------------------------------------------
+# get_market_status region routing (issue #37)
+# ---------------------------------------------------------------------------
+
+
+class _RegionAwareSource:
+    """get_market_status 만 가진 fake. region 인자를 받아 자기가 안 다루는 region
+    이면 NotImplementedError 를 raise — 실제 KoreanDataSource / YfinanceDataSource
+    가 이슈 #37 fix 후 동작하는 방식과 동일.
+    """
+
+    def __init__(self, name: str, supports: set[str]):
+        self.name = name
+        self.supports = supports
+        self.calls: list[dict] = []
+
+    async def get_market_status(self, user_id=None, region=None):
+        self.calls.append({"user_id": user_id, "region": region})
+        if region is not None and region not in self.supports:
+            raise NotImplementedError(
+                f"{self.name} only supports {self.supports}, got {region!r}"
+            )
+        return {"market": "open" if "open" in self.supports else "closed", "_source": self.name}
+
+    async def close(self):
+        pass
+
+
+class TestMarketStatusRegionRouting:
+    @pytest.mark.asyncio
+    async def test_kr_region_routes_to_korean_source(self):
+        """region='kr' → KR source 응답. US source 는 NotImplementedError 로 skip."""
+        kr_src = _RegionAwareSource("korean", supports={"kr", "open"})
+        us_src = _RegionAwareSource("yfinance", supports={"us"})
+        provider = MarketDataProvider([
+            ProviderEntry("yfinance", us_src, {"all"}),  # 'all' 마킹이지만 region='kr' 거절
+            ProviderEntry("korean", kr_src, {"kr"}),
+        ])
+        result = await provider.get_market_status(region="kr")
+        assert result["_source"] == "korean"
+        # us_src 가 먼저 시도됐으나 NotImplementedError 로 skip 됐는지 확인
+        assert us_src.calls == [{"user_id": None, "region": "kr"}]
+        assert kr_src.calls == [{"user_id": None, "region": "kr"}]
+
+    @pytest.mark.asyncio
+    async def test_us_region_routes_to_us_source(self):
+        kr_src = _RegionAwareSource("korean", supports={"kr"})
+        us_src = _RegionAwareSource("yfinance", supports={"us", "open"})
+        provider = MarketDataProvider([
+            ProviderEntry("korean", kr_src, {"kr"}),
+            ProviderEntry("yfinance", us_src, {"all"}),
+        ])
+        result = await provider.get_market_status(region="us")
+        assert result["_source"] == "yfinance"
+        # KR 은 region='us' 매칭에서 제외 (markets={'kr'} 만, 'all' 없음)
+        assert kr_src.calls == []
+        assert us_src.calls == [{"user_id": None, "region": "us"}]
+
+    @pytest.mark.asyncio
+    async def test_region_none_backward_compat(self):
+        """region=None 은 기존 동작 — chain 의 첫 번째 source 가 응답."""
+        kr_src = _RegionAwareSource("korean", supports={"kr"})
+        us_src = _RegionAwareSource("yfinance", supports={"us", "open"})
+        provider = MarketDataProvider([
+            ProviderEntry("korean", kr_src, {"kr"}),
+            ProviderEntry("yfinance", us_src, {"all"}),
+        ])
+        # region=None 은 모든 candidates. korean 이 첫 호출 — region=None 이라 거절 안 함.
+        result = await provider.get_market_status()
+        # kr source 가 region=None 을 받아 KR status 반환
+        assert result["_source"] == "korean"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_region_raises(self):
+        """어떤 source 도 region 을 지원 안 하면 마지막 NotImplementedError 가 raise."""
+        us_src = _RegionAwareSource("yfinance", supports={"us"})
+        provider = MarketDataProvider([
+            ProviderEntry("yfinance", us_src, {"all"}),
+        ])
+        with pytest.raises(NotImplementedError):
+            await provider.get_market_status(region="kr")
+
+    @pytest.mark.asyncio
+    async def test_korean_source_unit_rejects_non_kr_region(self):
+        """KoreanDataSource 자체가 region='us' 호출에 NotImplementedError."""
+        from src.data_client.korean.data_source import KoreanDataSource
+
+        source = KoreanDataSource()
+        with pytest.raises(NotImplementedError, match="region='kr'"):
+            await source.get_market_status(region="us")
+        # region='kr' 또는 None 은 정상
+        result = await source.get_market_status(region="kr")
+        assert "market" in result
+        result2 = await source.get_market_status(region=None)
+        assert "market" in result2
+
+
+# ---------------------------------------------------------------------------
 # FMPDataSource interval guard tests
 # ---------------------------------------------------------------------------
 

--- a/tests/unit/data_client/test_market_data_provider.py
+++ b/tests/unit/data_client/test_market_data_provider.py
@@ -314,6 +314,45 @@ class TestMarketStatusRegionRouting:
         result2 = await source.get_market_status(region=None)
         assert "market" in result2
 
+    @pytest.mark.asyncio
+    async def test_real_failure_surfaces_after_notimpl_skip(self):
+        """첫 source 가 NotImplementedError 로 skip 되고 두 번째가 generic Exception 으로
+        실패하면 generic Exception 이 raise (last_exc semantics).
+        """
+        class FailingSource:
+            async def get_market_status(self, user_id=None, region=None):
+                raise RuntimeError("upstream fetch boom")
+            async def close(self):
+                pass
+
+        kr_only = _RegionAwareSource("korean", supports={"kr"})
+        provider = MarketDataProvider([
+            ProviderEntry("korean", kr_only, {"kr"}),
+            ProviderEntry("primary", FailingSource(), {"all"}),
+        ])
+        with pytest.raises(RuntimeError, match="upstream fetch boom"):
+            await provider.get_market_status(region="us")
+
+    @pytest.mark.asyncio
+    async def test_notimpl_after_real_failure_surfaces_notimpl(self):
+        """첫 source 가 generic Exception, 두 번째가 NotImplementedError → 마지막
+        last_exc (NotImplementedError) 가 raise. real failure 가 sandbagged 되는 게
+        의도된 동작인지를 명세화.
+        """
+        class FailingSource:
+            async def get_market_status(self, user_id=None, region=None):
+                raise RuntimeError("upstream fetch boom")
+            async def close(self):
+                pass
+
+        skip_src = _RegionAwareSource("yfinance", supports={"us"})
+        provider = MarketDataProvider([
+            ProviderEntry("primary", FailingSource(), {"all"}),
+            ProviderEntry("yfinance", skip_src, {"all"}),
+        ])
+        with pytest.raises(NotImplementedError):
+            await provider.get_market_status(region="kr")
+
 
 # ---------------------------------------------------------------------------
 # FMPDataSource interval guard tests

--- a/web/src/lib/marketUtils.ts
+++ b/web/src/lib/marketUtils.ts
@@ -100,10 +100,15 @@ export async function searchStocks(query: string, limit = 50): Promise<StockSear
 /**
  * GET /api/v1/market-data/market-status
  * Returns { market, afterHours, earlyHours, serverTime, exchanges }
+ *
+ * FORK (#37): region 파라미터 — backend 가 region 별로 응답 (KR/US). 미지정 시 backend default ('us').
  */
-export async function fetchMarketStatus({ signal }: { signal?: AbortSignal } = {}): Promise<MarketStatusData> {
+export async function fetchMarketStatus(
+  { signal, region }: { signal?: AbortSignal; region?: string } = {},
+): Promise<MarketStatusData> {
   try {
-    const { data } = await api.get('/api/v1/market-data/market-status', { signal });
+    const params = region ? { region } : undefined;
+    const { data } = await api.get('/api/v1/market-data/market-status', { signal, params });
     return data || {};
   } catch (e: unknown) {
     const err = e as { name?: string; message?: string };

--- a/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
+++ b/web/src/pages/Dashboard/hooks/__tests__/useDashboardData.test.tsx
@@ -58,6 +58,36 @@ describe('useDashboardData', () => {
     expect(result.current.marketStatus!.market).toBe('open');
   });
 
+  it('passes region=us to fetchMarketStatus by default (en-US locale, auto market)', async () => {
+    renderHookWithProviders(() => useDashboardData());
+    await waitFor(() => {
+      expect(mockFetchMarketStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ region: 'us' }),
+      );
+    });
+  });
+
+  it('refetches marketStatus with region=kr when locale changes to ko-KR', async () => {
+    // FORK (#37): marketStatus useQuery 의 queryKey 에 region 포함 → market=kr 전환 시 자동 refetch
+    renderHookWithProviders(() => useDashboardData());
+    await waitFor(() => {
+      expect(mockFetchMarketStatus).toHaveBeenCalledWith(
+        expect.objectContaining({ region: 'us' }),
+      );
+    });
+
+    await act(async () => {
+      await i18n.changeLanguage('ko-KR');
+    });
+
+    await waitFor(() => {
+      const krCall = mockFetchMarketStatus.mock.calls.find(
+        (args) => (args[0] as { region?: string })?.region === 'kr',
+      );
+      expect(krCall).toBeDefined();
+    });
+  });
+
   it('returns indices data', async () => {
     const { result } = renderHookWithProviders(() => useDashboardData());
 

--- a/web/src/pages/Dashboard/hooks/useDashboardData.ts
+++ b/web/src/pages/Dashboard/hooks/useDashboardData.ts
@@ -69,10 +69,12 @@ export function useDashboardData(): DashboardData {
   const indexSet = useMemo(() => getIndexSetForMarket(region), [region]);
   const newsRegion = useMemo(() => getNewsRegionForMarket(region), [region]);
 
-  // 1. Market Status (Polls every 60s, cached globally)
+  // 1. Market Status (Polls every 60s, cached per region)
+  // FORK (#37): queryKey 에 region 포함 → 시장 전환 시 자동 refetch + KR/US 캐시 분리.
+  // KR 사용자가 KST 09:00-15:30 에 'open' 보고, US 사용자가 ET 09:30-16:00 에 'open' 보도록.
   const { data: marketStatus = null } = useQuery<MarketStatusData | null>({
-    queryKey: ['dashboard', 'marketStatus'],
-    queryFn: fetchMarketStatus,
+    queryKey: ['dashboard', 'marketStatus', region],
+    queryFn: ({ signal }) => fetchMarketStatus({ signal, region }),
     refetchInterval: 60000,
     refetchIntervalInBackground: false,
     staleTime: 30000,


### PR DESCRIPTION
## 요약
Closes #37

`/api/v1/market-data/market-status` 가 항상 NYSE 시간만 반환해 KR 사용자가 KST 정규장에 \"market closed\" 보는 혼란을 수정. region 쿼리 파라미터로 KR/US 분리.

## 변경 사항

### Backend
- `src/data_client/base.py`: `MarketDataSource.get_market_status` Protocol 에 `region` 파라미터 추가
- 각 source (`korean`, `yfinance`, `fmp`, `ginlix-data`): 자기가 다루지 않는 region 일 때 `NotImplementedError`
- `MarketDataProvider.get_market_status(region)`: region 매칭 source 우선 + 'all' source 도 후보. NotImplementedError 는 fallback 신호로 처리 (debug log)
- `/market-status` route: `region` Query 파라미터 (default 'us'), cache key `market:status:{region}` 으로 분리

### Frontend
- `fetchMarketStatus({ signal, region })`: region 쿼리 파라미터 전달
- `useDashboardData`: `useMarket().region` 으로 호출, queryKey `['dashboard', 'marketStatus', region]` 분리

## 기술적 판단
- **왜 source 별 region 검사 (Provider 의 strict matching 이 아닌)?** 'all' 마킹된 source (yfinance/fmp) 도 실제로는 NYSE 시간만 알고 있어, KR region 호출 시 잘못된 정보를 줄 위험. 하지만 strict matching 으로 'all' 을 제외하면 us region 에서 ginlix-data 가 unavailable 시 fallback 이 끊김. 절충안: source 가 자기 책임 검사 → KR 호출은 NotImplementedError 로 KoreanDataSource 까지 자연스럽게 흘러감. PR #31 의 `get_snapshots` 패턴과 동일.
- **region=None backward-compat**: 인증 미들웨어, 디버그 호출 등 region 모르는 caller 가 깨지지 않도록 chain 의 첫 source 응답을 그대로 반환.
- **KR 휴장일**: 본 PR 은 평일 + 09:00-15:30 KST 만 검사 (단순 v1). 공휴일 처리는 follow-up issue 로 분리 가능 (pykrx 거래일 캐시 + memoization 필요).

## 검증
- `uv run pytest tests/unit/data_client/ -v` → 151/151 통과 (5개 신규 회귀 케이스)
- `pnpm vitest run` → 560/560 통과 (2개 신규 회귀 케이스)
- `uv run ruff check src/data_client/ src/server/app/market_data.py tests/...` → clean
- `pnpm lint` → 0 errors / 53 warnings (기존)

## 의존
PR #38 (#34 Redis auth) 머지 전에는 region 별 cache 분리가 인증 실패로 작동 안 함. 본 PR 의 동작 자체는 cache 없어도 정상 (cache miss 시 매번 source 직접 호출).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **새로운 기능**
  * 시장 상태 조회에 지역 선택 기능이 추가되었습니다.
  * 사용자의 언어 설정에 따라 자동으로 해당 지역의 최신 시장 데이터를 조회합니다.
  * 지역별 캐싱으로 조회 성능이 개선되었습니다.
  * 요청된 지역을 지원하지 않는 데이터 소스는 자동으로 건너뛰며, 가장 적절한 소스에서 데이터를 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->