### PR TITLE
feat: MarketView timezone / TradingView 심볼 KR 지원 (#33 frontend slice)

### DIFF
--- a/web/src/lib/__tests__/marketTimezone.test.ts
+++ b/web/src/lib/__tests__/marketTimezone.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from 'vitest';
+import { getTimezoneForSymbol, toTradingViewSymbol } from '../marketTimezone';
+
+describe('getTimezoneForSymbol', () => {
+  it('returns Asia/Seoul for .KS (KOSPI)', () => {
+    expect(getTimezoneForSymbol('005930.KS')).toBe('Asia/Seoul');
+  });
+
+  it('returns Asia/Seoul for .KQ (KOSDAQ)', () => {
+    expect(getTimezoneForSymbol('263750.KQ')).toBe('Asia/Seoul');
+  });
+
+  it('case-insensitive on suffix', () => {
+    expect(getTimezoneForSymbol('005930.ks')).toBe('Asia/Seoul');
+    expect(getTimezoneForSymbol('263750.kq')).toBe('Asia/Seoul');
+  });
+
+  it('returns America/New_York for bare US ticker', () => {
+    expect(getTimezoneForSymbol('GOOGL')).toBe('America/New_York');
+    expect(getTimezoneForSymbol('AAPL')).toBe('America/New_York');
+  });
+
+  it('returns America/New_York for empty/null/undefined', () => {
+    expect(getTimezoneForSymbol('')).toBe('America/New_York');
+    expect(getTimezoneForSymbol(null)).toBe('America/New_York');
+    expect(getTimezoneForSymbol(undefined)).toBe('America/New_York');
+  });
+
+  it('returns America/New_York for unknown suffix (fallback)', () => {
+    // 향후 .HK / .T 추가 시 본 케이스 갱신
+    expect(getTimezoneForSymbol('0700.HK')).toBe('America/New_York');
+  });
+});
+
+describe('toTradingViewSymbol', () => {
+  it('maps .KS to KRX prefix', () => {
+    expect(toTradingViewSymbol('005930.KS')).toBe('KRX:005930');
+  });
+
+  it('maps .KQ to KRX prefix (KOSDAQ also uses KRX exchange)', () => {
+    expect(toTradingViewSymbol('263750.KQ')).toBe('KRX:263750');
+  });
+
+  it('case-insensitive on suffix', () => {
+    expect(toTradingViewSymbol('005930.ks')).toBe('KRX:005930');
+  });
+
+  it('passes US symbols through unchanged', () => {
+    expect(toTradingViewSymbol('GOOGL')).toBe('GOOGL');
+    expect(toTradingViewSymbol('AAPL')).toBe('AAPL');
+  });
+
+  it('returns empty string for null/undefined', () => {
+    expect(toTradingViewSymbol(null)).toBe('');
+    expect(toTradingViewSymbol(undefined)).toBe('');
+  });
+
+  it('passes unknown suffixes through (TradingView 가 자체 routing 시도)', () => {
+    expect(toTradingViewSymbol('0700.HK')).toBe('0700.HK');
+  });
+});

--- a/web/src/lib/marketTimezone.ts
+++ b/web/src/lib/marketTimezone.ts
@@ -1,0 +1,39 @@
+/**
+ * Symbol → market timezone / TradingView symbol mapping.
+ *
+ * FORK (#33): MarketView 의 timezone / symbol 처리가 US 만 가정해 한국 차트 (.KS/.KQ)
+ * 를 보면 NYSE 시간으로 잘못 표시되던 문제. backend 의 symbol_timezone 패턴을
+ * frontend 에 mirror.
+ */
+
+const US_TZ = 'America/New_York';
+const KR_TZ = 'Asia/Seoul';
+
+/**
+ * Derive IANA timezone from symbol suffix.
+ *
+ * - `.KS` (KOSPI) / `.KQ` (KOSDAQ) → `Asia/Seoul`
+ * - bare ticker, `.US` → `America/New_York`
+ * - 그 외 (HK / JP / EU 등) → `America/New_York` (현재 MarketView 미지원, 향후 확장 시 추가)
+ */
+export function getTimezoneForSymbol(symbol: string | null | undefined): string {
+  if (!symbol) return US_TZ;
+  if (/\.(KS|KQ)$/i.test(symbol)) return KR_TZ;
+  return US_TZ;
+}
+
+/**
+ * Convert a Yahoo-style symbol to a TradingView-compatible symbol.
+ *
+ * TradingView 의 한국 시장은 KOSPI/KOSDAQ 모두 `KRX` exchange 로 통합
+ * (예: `005930.KS` → `KRX:005930`). `.KS`/`.KQ` suffix 는 TradingView 가 직접
+ * 인식하지 못해 KRX prefix 변환이 필요.
+ *
+ * US 심볼 (bare ticker) 은 그대로 — TradingView 가 자체 routing.
+ */
+export function toTradingViewSymbol(symbol: string | null | undefined): string {
+  if (!symbol) return '';
+  const match = symbol.match(/^(.+)\.(KS|KQ)$/i);
+  if (match) return `KRX:${match[1]}`;
+  return symbol;
+}

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -30,6 +30,8 @@ import { loadPref, savePref } from '../utils/prefs';
 import type { SnapshotData } from '@/types/market';
 import type { BarData } from '../hooks/useMarketDataWS';
 import { useOnClickOutside } from '@/hooks/useOnClickOutside';
+// FORK (#33): KR symbol (.KS / .KQ) 일 때 차트 거래일 도출이 KST 기준이도록 분기
+import { getTimezoneForSymbol } from '@/lib/marketTimezone';
 
 interface ChartDataBar {
   time: number;
@@ -277,7 +279,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
           (async () => {
             try {
               const fromDate = new Date(lastDataTime * 1000).toISOString().split('T')[0];
-              const toDate = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+              const toDate = new Date().toLocaleDateString('en-CA', { timeZone: getTimezoneForSymbol(symbol) });
               const sym = symbol;
               const result = await fetchStockData(sym, interval, fromDate, toDate);
               if (symbolRef.current !== sym) return; // symbol changed, discard stale data
@@ -1255,13 +1257,14 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
         let fromDate, toDate;
         if (loadDays > 0) {
           const now = new Date();
-          toDate = now.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+          const tz = getTimezoneForSymbol(symbol);
+          toDate = now.toLocaleDateString('en-CA', { timeZone: tz });
           {
             const maxMaPeriod = Math.max(...enabledMaPeriodsRef.current, 0);
             const overheadDays = Math.ceil((maxMaPeriod / (BARS_PER_DAY[interval] || 1)) * 1.5);
             const from = new Date(now);
             from.setDate(from.getDate() - loadDays - overheadDays);
-            fromDate = from.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+            fromDate = from.toLocaleDateString('en-CA', { timeZone: tz });
           }
         }
 
@@ -1324,7 +1327,7 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
               if (interval === '1s' && oldestDateRef.current) {
                 const firstBarDate = new Date(oldestDateRef.current * 1000);
                 const firstBarMins = firstBarDate.getUTCHours() * 60 + firstBarDate.getUTCMinutes();
-                const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+                const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: getTimezoneForSymbol(symbol) });
                 const firstBarDateStr = firstBarDate.toISOString().split('T')[0];
 
                 // Fill if first bar is from today and starts after 4:30 AM ET (270 mins)
@@ -1449,13 +1452,14 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
       if (lastLiveTickTimeRef.current > Date.now() - 5000) return;
       try {
         const now = new Date();
-        const toDate = now.toLocaleDateString('en-CA', { timeZone: 'America/New_York' });
+        const tz = getTimezoneForSymbol(symbol);
+        const toDate = now.toLocaleDateString('en-CA', { timeZone: tz });
 
         // Delta-based: fetch only from last known bar's time onward
         const lastBar = allDataRef.current?.[allDataRef.current.length - 1];
         const fromDate = lastBar
           ? new Date(lastBar.time * 1000).toISOString().split('T')[0]
-          : (() => { const d = new Date(now); d.setDate(d.getDate() - 3); return d.toLocaleDateString('en-CA', { timeZone: 'America/New_York' }); })();
+          : (() => { const d = new Date(now); d.setDate(d.getDate() - 3); return d.toLocaleDateString('en-CA', { timeZone: tz }); })();
 
         const result = await fetchStockData(symbol, interval, fromDate, toDate);
         if (aborted) return;

--- a/web/src/pages/MarketView/components/MarketChart.tsx
+++ b/web/src/pages/MarketView/components/MarketChart.tsx
@@ -278,8 +278,10 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
           gapFillInProgressRef.current = true;
           (async () => {
             try {
-              const fromDate = new Date(lastDataTime * 1000).toISOString().split('T')[0];
-              const toDate = new Date().toLocaleDateString('en-CA', { timeZone: getTimezoneForSymbol(symbol) });
+              // FORK (#33): from/to 모두 시장 timezone 기준 — UTC 와 섞이면 KST/ET 자정 경계에서 하루 어긋남.
+              const tz = getTimezoneForSymbol(symbol);
+              const fromDate = new Date(lastDataTime * 1000).toLocaleDateString('en-CA', { timeZone: tz });
+              const toDate = new Date().toLocaleDateString('en-CA', { timeZone: tz });
               const sym = symbol;
               const result = await fetchStockData(sym, interval, fromDate, toDate);
               if (symbolRef.current !== sym) return; // symbol changed, discard stale data
@@ -1327,10 +1329,16 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
               if (interval === '1s' && oldestDateRef.current) {
                 const firstBarDate = new Date(oldestDateRef.current * 1000);
                 const firstBarMins = firstBarDate.getUTCHours() * 60 + firstBarDate.getUTCMinutes();
-                const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: getTimezoneForSymbol(symbol) });
-                const firstBarDateStr = firstBarDate.toISOString().split('T')[0];
+                // FORK (#33): firstBarDateStr 도 시장 timezone 기준으로 도출 — todayStr 과 일관.
+                const tz = getTimezoneForSymbol(symbol);
+                const todayStr = new Date().toLocaleDateString('en-CA', { timeZone: tz });
+                const firstBarDateStr = firstBarDate.toLocaleDateString('en-CA', { timeZone: tz });
 
-                // Fill if first bar is from today and starts after 4:30 AM ET (270 mins)
+                // Fill if first bar is from today and starts after 4:30 AM ET (270 mins).
+                // TODO (#33): 270min 은 NYSE 09:30 – 4:30 AM pre-market 기준 (US/ET-specific).
+                //   1s interval 은 현재 supports1sInterval(symbol) 가 US-only 로 게이트해 안전하지만,
+                //   향후 KR 등이 1s 지원되면 getTimezoneForSymbol(symbol) 기반 market-aware
+                //   threshold 로 분기 필요 (예: KST 09:00 시작 → 8:30 KST = ?).
                 if (firstBarDateStr === todayStr && firstBarMins > 270) {
                   try {
                     const gapResult = await fetchStockData(capturedSym, '1s', todayStr, todayStr,
@@ -1455,10 +1463,11 @@ const MarketChart = React.memo(forwardRef<MarketChartHandle, MarketChartProps>((
         const tz = getTimezoneForSymbol(symbol);
         const toDate = now.toLocaleDateString('en-CA', { timeZone: tz });
 
-        // Delta-based: fetch only from last known bar's time onward
+        // Delta-based: fetch only from last known bar's time onward.
+        // FORK (#33): lastBar 의 fromDate 도 시장 timezone 기준 — toDate 와 일관.
         const lastBar = allDataRef.current?.[allDataRef.current.length - 1];
         const fromDate = lastBar
-          ? new Date(lastBar.time * 1000).toISOString().split('T')[0]
+          ? new Date(lastBar.time * 1000).toLocaleDateString('en-CA', { timeZone: tz })
           : (() => { const d = new Date(now); d.setDate(d.getDate() - 3); return d.toLocaleDateString('en-CA', { timeZone: tz }); })();
 
         const result = await fetchStockData(symbol, interval, fromDate, toDate);

--- a/web/src/pages/MarketView/components/TradingViewWidget.tsx
+++ b/web/src/pages/MarketView/components/TradingViewWidget.tsx
@@ -1,5 +1,7 @@
 import React, { useEffect, useRef, memo } from 'react';
 import { useTheme } from '@/contexts/ThemeContext';
+// FORK (#33): KR symbol (.KS / .KQ) 일 때 KRX prefix 변환 + KST timezone
+import { getTimezoneForSymbol, toTradingViewSymbol } from '@/lib/marketTimezone';
 
 // Map our interval keys to TradingView widget interval values
 const TV_INTERVALS: Record<string, string> = {
@@ -46,9 +48,12 @@ function TradingViewWidget({ symbol, interval = '1day' }: TradingViewWidgetProps
     script.async = true;
     script.innerHTML = JSON.stringify({
       autosize: true,
-      symbol: symbol,
+      // FORK (#33): KR ticker (.KS/.KQ) 는 KRX:XXXXXX 형태로 변환, US 는 그대로.
+      // 사용자 OS timezone 대신 시장 timezone 사용 — 미국 사용자가 한국 차트
+      // 보면 KST 봉 시간이 정확.
+      symbol: toTradingViewSymbol(symbol),
       interval: TV_INTERVALS[interval] || 'D',
-      timezone: Intl.DateTimeFormat().resolvedOptions().timeZone || 'America/New_York',
+      timezone: getTimezoneForSymbol(symbol),
       theme: theme === 'light' ? 'light' : 'dark',
       style: '1', // Candlestick
       locale: 'en',


### PR DESCRIPTION
## 요약
Refs #33 (frontend-only 부분)

KR ticker (.KS / .KQ) 차트가 NYSE 시간 기반으로 거래일 도출하던 문제 + TradingView embed 가 .KS 심볼을 직접 인식 못 해 KR 차트가 빈 화면이던 문제를 수정.

## 변경 사항
- `web/src/lib/marketTimezone.ts` (신규)
  - `getTimezoneForSymbol(symbol)`: .KS/.KQ → Asia/Seoul, 그 외 → America/New_York
  - `toTradingViewSymbol(symbol)`: `005930.KS` → `KRX:005930` (KOSPI/KOSDAQ 모두 KRX exchange 통합)
- `web/src/pages/MarketView/components/MarketChart.tsx`
  - `'America/New_York'` 6곳 → `getTimezoneForSymbol(symbol)` (gap fill, 초기 fetch, 1s 보정, polling)
- `web/src/pages/MarketView/components/TradingViewWidget.tsx`
  - 사용자 OS timezone (`Intl.DateTimeFormat`) → 시장 timezone
  - symbol 그대로 → `toTradingViewSymbol` 변환

## 기술적 판단
- **왜 `useMarket().region` 이 아닌 symbol 기반?** user 가 market='kr' setting 이어도 GOOGL 차트 보면 NYSE timezone, market='us' 인데 005930.KS 보면 KST 가 정확. 차트가 표시하는 심볼 자체에서 도출하는 게 robust. backend 의 `symbol_timezone` 패턴과 동일.
- **왜 KRX prefix 변환?** TradingView 의 한국 시장은 KOSPI/KOSDAQ 모두 `KRX` exchange 로 통합 표기. `.KS` 직접 인식 안 됨. KOSPI/KOSDAQ 둘 다 `KRX:XXXXXX`.
- **scope 제외**: KR WebSocket source (옵션 A/B/C 결정 필요), /overview·/analyst-data region-aware 라우팅 — backend 변경 + 정책 결정 필요해 별도 PR

## 검증
- `pnpm vitest run src/lib/__tests__/marketTimezone.test.ts` → 12/12 통과
- `pnpm vitest run` → 570/570 통과 (회귀 zero)
- `pnpm lint` → 0 errors
- 수동: dev server 띄워 005930.KS / GOOGL 전환 시 차트 timezone 표시 검증 권장

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 거래 시장별로 적절한 타임존을 자동으로 감지하고 적용하는 기능 추가
  * 국제 차트 플랫폼의 심볼 형식으로 자동 변환하는 기능 추가

* **테스트**
  * 타임존 감지 및 심볼 변환 로직의 정확성을 검증하는 테스트 스위트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->