### PR TITLE
feat: KR ticker polling fallback + fundamentals graceful 미지원 (#33 backend)

### DIFF
--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -45,6 +45,22 @@ router = APIRouter(
 )
 
 
+# FORK (#33): /overview, /analyst-data 가 native source 가 없는 시장의 ticker
+# 를 받았을 때 graceful "미지원" 응답으로 처리. 향후 .HK / .T 등 추가 시 본 set
+# 에 추가하면 모든 endpoint 가 일관되게 동작. fundamentals 가 native 로 채워진
+# 시장 (예: KR via #42 pykrx + DART) 은 set 에서 제외.
+_UNSUPPORTED_FUNDAMENTALS_SUFFIXES: tuple[str, ...] = (".KS", ".KQ")
+
+
+def is_unsupported_market(symbol: str) -> bool:
+    """Return True if symbol's market lacks a native fundamentals source.
+
+    Symbol is normalized to upper-case before suffix check, matching the
+    handler's own normalization (``symbol.strip().upper()``).
+    """
+    return symbol.strip().upper().endswith(_UNSUPPORTED_FUNDAMENTALS_SUFFIXES)
+
+
 def _convert_data_points(raw_data: list) -> list[IntradayDataPoint]:
     """Convert raw OHLCV data to IntradayDataPoint models."""
     return [
@@ -478,14 +494,14 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
 
     symbol_upper = symbol.strip().upper()
 
-    # FORK (#33): KR ticker (.KS / .KQ) 는 현재 fundamentals source 없음. 200 with
-    # unsupported=True 응답 — frontend 가 graceful "한국 시장 미지원" 카드 렌더.
-    # #42 에서 pykrx + DART 로 채워질 예정.
-    if symbol_upper.endswith((".KS", ".KQ")):
+    # FORK (#33): native fundamentals source 가 없는 시장은 graceful 미지원 응답.
+    # message 는 영어 fallback — frontend 가 i18n 키 (marketView.fundamentalsUnsupported)
+    # 로 사용자 locale 에 맞게 표시.
+    if is_unsupported_market(symbol_upper):
         return CompanyOverviewResponse(
             symbol=symbol_upper,
             unsupported=True,
-            message="한국 시장 fundamentals 는 현재 지원되지 않습니다 (#42 에서 추가 예정).",
+            message="Fundamentals are not yet supported for this market.",
         )
 
     try:
@@ -546,13 +562,13 @@ async def get_analyst_data(
 
     symbol_upper = symbol.strip().upper()
 
-    # FORK (#33): KR ticker 는 native analyst rating source 없음. graceful 미지원 응답.
-    if symbol_upper.endswith((".KS", ".KQ")):
+    # FORK (#33): native analyst rating source 가 없는 시장은 graceful 미지원 응답.
+    if is_unsupported_market(symbol_upper):
         return AnalystDataResponse(
             symbol=symbol_upper,
             grades=[],
             unsupported=True,
-            message="한국 시장 애널리스트 데이터는 현재 지원되지 않습니다.",
+            message="Analyst data is not yet supported for this market.",
         )
 
     try:

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -477,6 +477,17 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
         raise HTTPException(status_code=422, detail="Symbol is required")
 
     symbol_upper = symbol.strip().upper()
+
+    # FORK (#33): KR ticker (.KS / .KQ) 는 현재 fundamentals source 없음. 200 with
+    # unsupported=True 응답 — frontend 가 graceful "한국 시장 미지원" 카드 렌더.
+    # #42 에서 pykrx + DART 로 채워질 예정.
+    if symbol_upper.endswith((".KS", ".KQ")):
+        return CompanyOverviewResponse(
+            symbol=symbol_upper,
+            unsupported=True,
+            message="한국 시장 fundamentals 는 현재 지원되지 않습니다 (#42 에서 추가 예정).",
+        )
+
     try:
         from src.utils.cache.redis_cache import get_cache_client
 
@@ -534,6 +545,15 @@ async def get_analyst_data(
         raise HTTPException(status_code=422, detail="Symbol is required")
 
     symbol_upper = symbol.strip().upper()
+
+    # FORK (#33): KR ticker 는 native analyst rating source 없음. graceful 미지원 응답.
+    if symbol_upper.endswith((".KS", ".KQ")):
+        return AnalystDataResponse(
+            symbol=symbol_upper,
+            grades=[],
+            unsupported=True,
+            message="한국 시장 애널리스트 데이터는 현재 지원되지 않습니다.",
+        )
 
     try:
         import asyncio

--- a/src/server/models/market_data.py
+++ b/src/server/models/market_data.py
@@ -218,6 +218,10 @@ class CompanyOverviewResponse(BaseModel):
     cashFlow: Optional[List[Dict[str, Any]]] = Field(None, description="Quarterly cash flow data")
     revenueByProduct: Optional[Dict[str, Any]] = Field(None, description="Revenue breakdown by product")
     revenueByGeo: Optional[Dict[str, Any]] = Field(None, description="Revenue breakdown by geography")
+    # FORK (#33): KR ticker (.KS / .KQ) 는 현재 fundamentals source 없음. unsupported=True 면
+    # 모든 데이터 필드는 None, message 에 사유. 향후 #42 (pykrx + DART 기반) 로 채워질 예정.
+    unsupported: bool = Field(False, description="True if this market is not supported for fundamentals")
+    message: Optional[str] = Field(None, description="Human-readable explanation when unsupported=True")
 
 
 class PriceTargetSummary(BaseModel):
@@ -242,6 +246,10 @@ class AnalystDataResponse(BaseModel):
     symbol: str = Field(..., description="Stock ticker symbol")
     priceTargets: Optional[PriceTargetSummary] = Field(None, description="Price target summary")
     grades: List[AnalystGrade] = Field(default_factory=list, description="Recent analyst grade changes")
+    # FORK (#33): KR 시장은 native analyst rating 데이터 source 없음 (DART 공시 sentiment 로
+    # 대체할 수도 있으나 별도 작업). unsupported=True 면 priceTargets=None, grades=[].
+    unsupported: bool = Field(False, description="True if this market is not supported for analyst data")
+    message: Optional[str] = Field(None, description="Human-readable explanation when unsupported=True")
 
 
 class SnapshotData(BaseModel):

--- a/tests/unit/server/app/test_market_data_kr_unsupported.py
+++ b/tests/unit/server/app/test_market_data_kr_unsupported.py
@@ -11,7 +11,26 @@ import pytest
 from src.server.app.market_data import (
     get_analyst_data,
     get_company_overview,
+    is_unsupported_market,
 )
+
+
+class TestIsUnsupportedMarket:
+    """Helper 직접 검증 — overview/analyst 외 endpoint 가 추후 같은 helper 쓸 수 있도록."""
+
+    def test_kospi_kosdaq_suffixes(self):
+        assert is_unsupported_market("005930.KS") is True
+        assert is_unsupported_market("263750.KQ") is True
+
+    def test_case_insensitive_via_normalize(self):
+        # helper 자체가 strip + upper 처리 — handler 와 동일한 normalize 보장
+        assert is_unsupported_market("005930.ks") is True
+        assert is_unsupported_market("  263750.kq  ") is True
+
+    def test_us_and_unknown_are_supported(self):
+        assert is_unsupported_market("GOOGL") is False
+        assert is_unsupported_market("AAPL") is False
+        assert is_unsupported_market("0700.HK") is False  # 향후 추가 시 본 케이스 갱신
 
 
 class TestCompanyOverviewKRUnsupported:
@@ -20,8 +39,9 @@ class TestCompanyOverviewKRUnsupported:
         result = await get_company_overview(symbol="005930.KS", user_id="test-user")
         assert result.symbol == "005930.KS"
         assert result.unsupported is True
+        # message 는 영어 fallback — frontend 가 i18n key 로 사용자 locale 에 맞게 표시.
         assert result.message is not None
-        assert "한국" in result.message
+        assert "supported" in result.message.lower()
         # 모든 데이터 필드는 None — frontend 가 안전하게 빈 카드 렌더
         assert result.quote is None
         assert result.performance is None
@@ -35,9 +55,11 @@ class TestCompanyOverviewKRUnsupported:
 
     @pytest.mark.asyncio
     async def test_lowercase_kr_suffix_returns_unsupported(self):
-        # symbol 은 backend 에서 upper() 처리되므로 소문자도 매칭돼야 함
-        result = await get_company_overview(symbol="005930.ks", user_id="test-user")
+        # symbol 은 backend 에서 strip().upper() 처리되므로 소문자/공백도 매칭.
+        # 반환되는 symbol 도 normalize 된 형태인지 검증 — 회귀 방지.
+        result = await get_company_overview(symbol="  005930.ks  ", user_id="test-user")
         assert result.unsupported is True
+        assert result.symbol == "005930.KS"
 
 
 class TestAnalystDataKRUnsupported:

--- a/tests/unit/server/app/test_market_data_kr_unsupported.py
+++ b/tests/unit/server/app/test_market_data_kr_unsupported.py
@@ -1,0 +1,56 @@
+"""
+Tests for /overview, /analyst-data graceful 미지원 응답 (issue #33 backend slice).
+
+KR ticker (.KS / .KQ) 호출 시 200 with unsupported=True 로 응답해야 함 — frontend
+가 graceful "한국 시장 미지원" 카드 렌더할 수 있도록. user_id / DB / cache 모두
+무관 (early-return 분기) 이라 mock 없이 직접 함수 호출.
+"""
+
+import pytest
+
+from src.server.app.market_data import (
+    get_analyst_data,
+    get_company_overview,
+)
+
+
+class TestCompanyOverviewKRUnsupported:
+    @pytest.mark.asyncio
+    async def test_kospi_ticker_returns_unsupported(self):
+        result = await get_company_overview(symbol="005930.KS", user_id="test-user")
+        assert result.symbol == "005930.KS"
+        assert result.unsupported is True
+        assert result.message is not None
+        assert "한국" in result.message
+        # 모든 데이터 필드는 None — frontend 가 안전하게 빈 카드 렌더
+        assert result.quote is None
+        assert result.performance is None
+        assert result.quarterlyFundamentals is None
+
+    @pytest.mark.asyncio
+    async def test_kosdaq_ticker_returns_unsupported(self):
+        result = await get_company_overview(symbol="263750.KQ", user_id="test-user")
+        assert result.unsupported is True
+        assert result.symbol == "263750.KQ"
+
+    @pytest.mark.asyncio
+    async def test_lowercase_kr_suffix_returns_unsupported(self):
+        # symbol 은 backend 에서 upper() 처리되므로 소문자도 매칭돼야 함
+        result = await get_company_overview(symbol="005930.ks", user_id="test-user")
+        assert result.unsupported is True
+
+
+class TestAnalystDataKRUnsupported:
+    @pytest.mark.asyncio
+    async def test_kospi_ticker_returns_unsupported(self):
+        result = await get_analyst_data(symbol="005930.KS", user_id="test-user")
+        assert result.symbol == "005930.KS"
+        assert result.unsupported is True
+        assert result.message is not None
+        assert result.priceTargets is None
+        assert result.grades == []
+
+    @pytest.mark.asyncio
+    async def test_kosdaq_ticker_returns_unsupported(self):
+        result = await get_analyst_data(symbol="263750.KQ", user_id="test-user")
+        assert result.unsupported is True

--- a/web/src/lib/__tests__/marketTimezone.test.ts
+++ b/web/src/lib/__tests__/marketTimezone.test.ts
@@ -1,5 +1,22 @@
 import { describe, it, expect } from 'vitest';
-import { getTimezoneForSymbol, toTradingViewSymbol } from '../marketTimezone';
+import { getTimezoneForSymbol, isKoreanSymbol, toTradingViewSymbol } from '../marketTimezone';
+
+describe('isKoreanSymbol', () => {
+  it('true for .KS / .KQ (case-insensitive)', () => {
+    expect(isKoreanSymbol('005930.KS')).toBe(true);
+    expect(isKoreanSymbol('263750.KQ')).toBe(true);
+    expect(isKoreanSymbol('005930.ks')).toBe(true);
+  });
+
+  it('false for US / unknown / empty', () => {
+    expect(isKoreanSymbol('GOOGL')).toBe(false);
+    expect(isKoreanSymbol('AAPL')).toBe(false);
+    expect(isKoreanSymbol('0700.HK')).toBe(false);
+    expect(isKoreanSymbol('')).toBe(false);
+    expect(isKoreanSymbol(null)).toBe(false);
+    expect(isKoreanSymbol(undefined)).toBe(false);
+  });
+});
 
 describe('getTimezoneForSymbol', () => {
   it('returns Asia/Seoul for .KS (KOSPI)', () => {

--- a/web/src/lib/marketTimezone.ts
+++ b/web/src/lib/marketTimezone.ts
@@ -23,6 +23,17 @@ export function getTimezoneForSymbol(symbol: string | null | undefined): string 
 }
 
 /**
+ * True if symbol is a Korean ticker (KOSPI .KS / KOSDAQ .KQ).
+ *
+ * 본 fork 에서 KR 시장은 backend WebSocket source 가 없어 polling fallback 으로
+ * 동작. fundamentals/analyst 도 graceful "미지원" 처리. 이 분기를 위한 단일 진리.
+ */
+export function isKoreanSymbol(symbol: string | null | undefined): boolean {
+  if (!symbol) return false;
+  return /\.(KS|KQ)$/i.test(symbol);
+}
+
+/**
  * Convert a Yahoo-style symbol to a TradingView-compatible symbol.
  *
  * TradingView 의 한국 시장은 KOSPI/KOSDAQ 모두 `KRX` exchange 로 통합

--- a/web/src/lib/marketTimezone.ts
+++ b/web/src/lib/marketTimezone.ts
@@ -9,6 +9,21 @@
 const US_TZ = 'America/New_York';
 const KR_TZ = 'Asia/Seoul';
 
+// 단일 진리 — Korean suffix 추가/변경 시 본 정규식 한 곳만 수정.
+const KR_SUFFIX_RE = /\.(KS|KQ)$/i;
+
+/**
+ * True if symbol is a Korean ticker (KOSPI .KS / KOSDAQ .KQ).
+ *
+ * 본 fork 에서 KR 시장은 backend WebSocket source 가 없어 polling fallback 으로
+ * 동작. fundamentals/analyst 도 graceful "미지원" 처리. 이 분기를 위한 단일 진리 —
+ * getTimezoneForSymbol / toTradingViewSymbol 도 본 함수를 사용.
+ */
+export function isKoreanSymbol(symbol: string | null | undefined): boolean {
+  if (!symbol) return false;
+  return KR_SUFFIX_RE.test(symbol);
+}
+
 /**
  * Derive IANA timezone from symbol suffix.
  *
@@ -17,20 +32,8 @@ const KR_TZ = 'Asia/Seoul';
  * - 그 외 (HK / JP / EU 등) → `America/New_York` (현재 MarketView 미지원, 향후 확장 시 추가)
  */
 export function getTimezoneForSymbol(symbol: string | null | undefined): string {
-  if (!symbol) return US_TZ;
-  if (/\.(KS|KQ)$/i.test(symbol)) return KR_TZ;
+  if (isKoreanSymbol(symbol)) return KR_TZ;
   return US_TZ;
-}
-
-/**
- * True if symbol is a Korean ticker (KOSPI .KS / KOSDAQ .KQ).
- *
- * 본 fork 에서 KR 시장은 backend WebSocket source 가 없어 polling fallback 으로
- * 동작. fundamentals/analyst 도 graceful "미지원" 처리. 이 분기를 위한 단일 진리.
- */
-export function isKoreanSymbol(symbol: string | null | undefined): boolean {
-  if (!symbol) return false;
-  return /\.(KS|KQ)$/i.test(symbol);
 }
 
 /**
@@ -44,7 +47,9 @@ export function isKoreanSymbol(symbol: string | null | undefined): boolean {
  */
 export function toTradingViewSymbol(symbol: string | null | undefined): string {
   if (!symbol) return '';
-  const match = symbol.match(/^(.+)\.(KS|KQ)$/i);
-  if (match) return `KRX:${match[1]}`;
+  if (isKoreanSymbol(symbol)) {
+    // KS / KQ 둘 다 KRX 매핑. KR_SUFFIX_RE 가 보장하는 ".XX" suffix 제거.
+    return `KRX:${symbol.slice(0, -3)}`;
+  }
   return symbol;
 }

--- a/web/src/locales/en-US.json
+++ b/web/src/locales/en-US.json
@@ -979,5 +979,8 @@
     "flashModelLabel": "Flash model",
     "notSet": "Not set",
     "notConfigured": "Not configured"
+  },
+  "marketView": {
+    "fundamentalsUnsupported": "Fundamentals are not yet supported for this market."
   }
 }

--- a/web/src/locales/ko-KR.json
+++ b/web/src/locales/ko-KR.json
@@ -967,5 +967,8 @@
     "flashModelLabel": "Flash 모델",
     "notSet": "미설정",
     "notConfigured": "미구성"
+  },
+  "marketView": {
+    "fundamentalsUnsupported": "이 시장은 현재 fundamentals 가 지원되지 않습니다."
   }
 }

--- a/web/src/locales/zh-CN.json
+++ b/web/src/locales/zh-CN.json
@@ -969,5 +969,8 @@
     "flashModelLabel": "快速模型",
     "notSet": "未设置",
     "notConfigured": "未配置"
+  },
+  "marketView": {
+    "fundamentalsUnsupported": "此市场暂不支持基本面数据。"
   }
 }

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -23,6 +23,9 @@ import { MarketDataWSProvider, useMarketDataWSContext } from './contexts/MarketD
 import { loadPref, savePref } from './utils/prefs';
 // FORK (#32): 시장에 맞춰 첫 진입 디폴트 심볼 분기. 시장별로 마지막 본 종목을 분리 저장 → KR/US 전환 시 cross-bleed 방지.
 import { useMarket, type MarketRegion } from '@/contexts/MarketContext';
+// FORK (#33): KR ticker 는 WebSocket source 부재 → 60s snapshot polling fallback. isKoreanSymbol 로 단일 진리.
+import { isKoreanSymbol } from '@/lib/marketTimezone';
+import { useKoreanSnapshotPolling } from './hooks/useKoreanSnapshotPolling';
 
 // 시장별 첫 진입 디폴트 종목. localStorage 의 시장별 키가 비어있을 때만 사용.
 // 한국 시장 backend 인프라 (실시간 시세 / fundamentals) 는 #33 에서 다뤄지며,
@@ -233,17 +236,25 @@ function MarketViewInner() {
     setShowOverview(false);
   }, []);
 
-  // Subscribe selected stock to WS feed
+  // Subscribe selected stock to WS feed.
+  // FORK (#33): KR ticker (.KS / .KQ) 는 backend WebSocket source 가 없어 subscribe 자체를
+  // skip — useKoreanSnapshotPolling 이 60s snapshot polling 으로 대체.
+  const isKR = isKoreanSymbol(selectedStock);
   useEffect(() => {
-    if (!selectedStock) return;
+    if (!selectedStock || isKR) return;
     wsSubscribe([selectedStock]);
     return () => wsUnsubscribe([selectedStock]);
-  }, [selectedStock, wsSubscribe, wsUnsubscribe]);
+  }, [selectedStock, isKR, wsSubscribe, wsUnsubscribe]);
 
-  // Display price: prefer WS live data over REST. Only use realTimePrice if it
-  // belongs to the current symbol (prevents stale data flash when switching tickers).
+  // FORK (#33): KR polling 결과 (selectedStock 이 KR 일 때만 활성, US 면 항상 null)
+  const krPollPrice = useKoreanSnapshotPolling(isKR ? selectedStock : null);
+
+  // Display price: KR 면 polling 결과, US 면 WS live → REST fallback.
+  // Only use realTimePrice if it belongs to the current symbol (prevents stale data flash when switching tickers).
   const realTimePriceMatch = realTimePrice?.symbol === selectedStock ? realTimePrice : null;
-  const displayPrice = wsPrices.get(selectedStock) || realTimePriceMatch;
+  const displayPrice = isKR
+    ? krPollPrice
+    : wsPrices.get(selectedStock) || realTimePriceMatch;
 
   // Fetch workspaces for the workspace selector (deep mode)
   useEffect(() => {

--- a/web/src/pages/MarketView/MarketView.tsx
+++ b/web/src/pages/MarketView/MarketView.tsx
@@ -238,7 +238,7 @@ function MarketViewInner() {
 
   // Subscribe selected stock to WS feed.
   // FORK (#33): KR ticker (.KS / .KQ) 는 backend WebSocket source 가 없어 subscribe 자체를
-  // skip — useKoreanSnapshotPolling 이 60s snapshot polling 으로 대체.
+  // skip — useKoreanSnapshotPolling 이 KR symbol 만 받으면 자체적으로 polling, 그 외엔 idle.
   const isKR = isKoreanSymbol(selectedStock);
   useEffect(() => {
     if (!selectedStock || isKR) return;
@@ -246,8 +246,8 @@ function MarketViewInner() {
     return () => wsUnsubscribe([selectedStock]);
   }, [selectedStock, isKR, wsSubscribe, wsUnsubscribe]);
 
-  // FORK (#33): KR polling 결과 (selectedStock 이 KR 일 때만 활성, US 면 항상 null)
-  const krPollPrice = useKoreanSnapshotPolling(isKR ? selectedStock : null);
+  // FORK (#33): hook 자체가 KR 검사 — 외부 가드 불필요 (US symbol 이면 query disabled).
+  const krPollPrice = useKoreanSnapshotPolling(selectedStock);
 
   // Display price: KR 면 polling 결과, US 면 WS live → REST fallback.
   // Only use realTimePrice if it belongs to the current symbol (prevents stale data flash when switching tickers).

--- a/web/src/pages/MarketView/components/CompanyOverviewPanel.css
+++ b/web/src/pages/MarketView/components/CompanyOverviewPanel.css
@@ -82,6 +82,21 @@
   padding: 0 20px;
 }
 
+/* FORK (#33): unsupported market 안내 — error 가 아닌 informational 톤 (회색 / 둥근 카드). */
+.company-overview-notice {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 200px;
+  color: var(--color-text-secondary);
+  font-size: 13px;
+  text-align: center;
+  padding: 24px;
+  background: var(--color-bg-subtle, transparent);
+  border-radius: 8px;
+  line-height: 1.5;
+}
+
 @media (max-width: 767px) {
   .company-overview-panel {
     width: 100%;

--- a/web/src/pages/MarketView/components/CompanyOverviewPanel.tsx
+++ b/web/src/pages/MarketView/components/CompanyOverviewPanel.tsx
@@ -43,6 +43,9 @@ interface OverviewData {
   cashFlow?: unknown;
   revenueByProduct?: unknown;
   revenueByGeo?: unknown;
+  // FORK (#33): backend 가 KR ticker 시 unsupported=true 로 응답 — frontend 가 graceful 카드 렌더.
+  unsupported?: boolean;
+  message?: string;
   [key: string]: unknown;
 }
 
@@ -146,7 +149,14 @@ export default function CompanyOverviewPanel({ symbol: _symbol, visible, onClose
         <div className="company-overview-error">{error}</div>
       )}
 
-      {data && !loading && (
+      {/* FORK (#33): KR ticker 같이 backend 가 unsupported=true 응답하면 안내 카드 단독 표시. */}
+      {data?.unsupported && !loading && (
+        <div className="company-overview-error" style={{ lineHeight: 1.5 }}>
+          {data.message || '이 시장은 현재 fundamentals 가 지원되지 않습니다.'}
+        </div>
+      )}
+
+      {data && !data.unsupported && !loading && (
         <div style={{ display: 'flex', flexDirection: 'column', gap: 20 }}>
           <QuoteSummary data={data} />
           <PerformanceBarChart performance={data.performance as Record<string, number> | undefined} />

--- a/web/src/pages/MarketView/components/CompanyOverviewPanel.tsx
+++ b/web/src/pages/MarketView/components/CompanyOverviewPanel.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { useTranslation } from 'react-i18next';
 import { X, Loader2 } from 'lucide-react';
 import {
   PerformanceBarChart,
@@ -125,6 +126,7 @@ function QuoteSummary({ data }: QuoteSummaryProps) {
 }
 
 export default function CompanyOverviewPanel({ symbol: _symbol, visible, onClose, data, loading }: CompanyOverviewPanelProps) {
+  const { t } = useTranslation();
   if (!visible) return null;
 
   const error = !data && !loading ? 'No data available' : null;
@@ -149,10 +151,10 @@ export default function CompanyOverviewPanel({ symbol: _symbol, visible, onClose
         <div className="company-overview-error">{error}</div>
       )}
 
-      {/* FORK (#33): KR ticker 같이 backend 가 unsupported=true 응답하면 안내 카드 단독 표시. */}
+      {/* FORK (#33): backend 가 unsupported=true 응답하면 informational 안내 카드 (error 톤 아님). */}
       {data?.unsupported && !loading && (
-        <div className="company-overview-error" style={{ lineHeight: 1.5 }}>
-          {data.message || '이 시장은 현재 fundamentals 가 지원되지 않습니다.'}
+        <div className="company-overview-notice">
+          {t('marketView.fundamentalsUnsupported', { defaultValue: data.message ?? '' })}
         </div>
       )}
 

--- a/web/src/pages/MarketView/hooks/__tests__/useKoreanSnapshotPolling.test.ts
+++ b/web/src/pages/MarketView/hooks/__tests__/useKoreanSnapshotPolling.test.ts
@@ -1,0 +1,44 @@
+/**
+ * Unit tests for KR market hours guard inside useKoreanSnapshotPolling.
+ *
+ * 본 테스트는 hook 자체 (React Query 통합) 가 아닌 isKRMarketOpen 시간 검사 logic
+ * 만 검증. hook 동작 (refetch / disabled) 은 useDashboardData 와 동일 React Query
+ * 패턴이라 별도 통합 테스트 불필요.
+ */
+import { describe, it, expect } from 'vitest';
+import { __test_isKRMarketOpen } from '../useKoreanSnapshotPolling';
+
+function utcDateForKST(year: number, month: number, day: number, hour: number, minute = 0): Date {
+  // KST = UTC+9 → UTC time = KST - 9h
+  return new Date(Date.UTC(year, month - 1, day, hour - 9, minute));
+}
+
+describe('isKRMarketOpen (KST 09:00–15:30 weekdays)', () => {
+  it('open at 09:00 weekday', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 27, 9, 0))).toBe(true); // Mon
+  });
+
+  it('open at 15:30 weekday (boundary inclusive)', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 27, 15, 30))).toBe(true);
+  });
+
+  it('closed at 08:59 weekday (just before open)', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 27, 8, 59))).toBe(false);
+  });
+
+  it('closed at 15:31 weekday (just after close)', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 27, 15, 31))).toBe(false);
+  });
+
+  it('closed on Saturday during market hours', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 25, 11, 0))).toBe(false); // Sat
+  });
+
+  it('closed on Sunday during market hours', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 26, 11, 0))).toBe(false); // Sun
+  });
+
+  it('closed at midnight weekday', () => {
+    expect(__test_isKRMarketOpen(utcDateForKST(2026, 4, 27, 0, 0))).toBe(false);
+  });
+});

--- a/web/src/pages/MarketView/hooks/useKoreanSnapshotPolling.ts
+++ b/web/src/pages/MarketView/hooks/useKoreanSnapshotPolling.ts
@@ -1,0 +1,76 @@
+/**
+ * useKoreanSnapshotPolling — KR ticker 의 60s snapshot polling.
+ *
+ * FORK (#33): 본 fork 의 backend 에 KR 시장 WebSocket source 가 없어 (한투/키움 OAuth
+ * 부담, ginlix-data 외부 종속) realtime 대신 polling 으로 fallback. 단일 사용자
+ * self-hosted production 컨텍스트에서 polling traffic 미미. KR 정규장 09:00–15:30 (KST)
+ * 짧고, 60s lag 은 dashboard 모니터링에 충분.
+ *
+ * symbol 이 KR 아니면 (.KS / .KQ 외) no-op — US 심볼은 useMarketDataWS 가 담당.
+ */
+import { useEffect, useState } from 'react';
+import { fetchSnapshot } from '../utils/api';
+import type { PriceUpdate } from './useMarketDataWS';
+import { isKoreanSymbol } from '@/lib/marketTimezone';
+
+const POLLING_INTERVAL_MS = 60_000;
+
+export function useKoreanSnapshotPolling(symbol: string | null): PriceUpdate | null {
+  const [price, setPrice] = useState<PriceUpdate | null>(null);
+
+  useEffect(() => {
+    if (!symbol || !isKoreanSymbol(symbol)) {
+      setPrice(null);
+      return;
+    }
+
+    let aborted = false;
+
+    const fetchOnce = async () => {
+      try {
+        const snap = await fetchSnapshot(symbol);
+        if (aborted || !snap) return;
+        const close = snap.price ?? 0;
+        const prev = snap.previous_close ?? 0;
+        const change = snap.change ?? (prev ? close - prev : 0);
+        const pct = snap.change_percent ?? (prev ? (change / prev) * 100 : 0);
+        const open = snap.open ?? 0;
+        const high = snap.high ?? 0;
+        const low = snap.low ?? 0;
+        const volume = snap.volume ?? 0;
+
+        setPrice({
+          symbol: snap.symbol || symbol,
+          price: close,
+          open,
+          high,
+          low,
+          close,
+          volume,
+          change,
+          changePercent: pct,
+          timestamp: Date.now(),
+          barData: {
+            time: Math.floor(Date.now() / 1000),
+            open,
+            high,
+            low,
+            close,
+            volume,
+          },
+        });
+      } catch (err) {
+        if (!aborted) console.warn('[KR polling] snapshot failed:', err);
+      }
+    };
+
+    fetchOnce();
+    const id = setInterval(fetchOnce, POLLING_INTERVAL_MS);
+    return () => {
+      aborted = true;
+      clearInterval(id);
+    };
+  }, [symbol]);
+
+  return price;
+}

--- a/web/src/pages/MarketView/hooks/useKoreanSnapshotPolling.ts
+++ b/web/src/pages/MarketView/hooks/useKoreanSnapshotPolling.ts
@@ -2,75 +2,82 @@
  * useKoreanSnapshotPolling — KR ticker 의 60s snapshot polling.
  *
  * FORK (#33): 본 fork 의 backend 에 KR 시장 WebSocket source 가 없어 (한투/키움 OAuth
- * 부담, ginlix-data 외부 종속) realtime 대신 polling 으로 fallback. 단일 사용자
- * self-hosted production 컨텍스트에서 polling traffic 미미. KR 정규장 09:00–15:30 (KST)
- * 짧고, 60s lag 은 dashboard 모니터링에 충분.
+ * 부담, ginlix-data 외부 종속) realtime 대신 polling 으로 fallback. React Query 로
+ * 위임해 dedup / abort / visibility (refetchIntervalInBackground=false) 자동 처리.
  *
- * symbol 이 KR 아니면 (.KS / .KQ 외) no-op — US 심볼은 useMarketDataWS 가 담당.
+ * symbol 이 KR 아니면 (.KS / .KQ 외) query disabled — useDashboardData 패턴과 동일.
+ *
+ * KR 정규장 (KST 09:00–15:30) 외 시간에는 polling interval 을 늘려 traffic 절감
+ * (closed 면 5분, open 이면 60초). 마지막 snapshot 은 staleTime 동안 캐시되어
+ * 시장 closed 시 사용자에게 직전 종가 표시.
  */
-import { useEffect, useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
 import { fetchSnapshot } from '../utils/api';
 import type { PriceUpdate } from './useMarketDataWS';
 import { isKoreanSymbol } from '@/lib/marketTimezone';
 
-const POLLING_INTERVAL_MS = 60_000;
+const OPEN_INTERVAL_MS = 60_000;
+const CLOSED_INTERVAL_MS = 5 * 60_000;
 
-export function useKoreanSnapshotPolling(symbol: string | null): PriceUpdate | null {
-  const [price, setPrice] = useState<PriceUpdate | null>(null);
-
-  useEffect(() => {
-    if (!symbol || !isKoreanSymbol(symbol)) {
-      setPrice(null);
-      return;
-    }
-
-    let aborted = false;
-
-    const fetchOnce = async () => {
-      try {
-        const snap = await fetchSnapshot(symbol);
-        if (aborted || !snap) return;
-        const close = snap.price ?? 0;
-        const prev = snap.previous_close ?? 0;
-        const change = snap.change ?? (prev ? close - prev : 0);
-        const pct = snap.change_percent ?? (prev ? (change / prev) * 100 : 0);
-        const open = snap.open ?? 0;
-        const high = snap.high ?? 0;
-        const low = snap.low ?? 0;
-        const volume = snap.volume ?? 0;
-
-        setPrice({
-          symbol: snap.symbol || symbol,
-          price: close,
-          open,
-          high,
-          low,
-          close,
-          volume,
-          change,
-          changePercent: pct,
-          timestamp: Date.now(),
-          barData: {
-            time: Math.floor(Date.now() / 1000),
-            open,
-            high,
-            low,
-            close,
-            volume,
-          },
-        });
-      } catch (err) {
-        if (!aborted) console.warn('[KR polling] snapshot failed:', err);
-      }
-    };
-
-    fetchOnce();
-    const id = setInterval(fetchOnce, POLLING_INTERVAL_MS);
-    return () => {
-      aborted = true;
-      clearInterval(id);
-    };
-  }, [symbol]);
-
-  return price;
+/** KST 평일 09:00–15:30 (정규장) 검사 — 단순한 시간 기반, 휴장일 미반영. */
+function isKRMarketOpen(now: Date = new Date()): boolean {
+  // KST = UTC+9. browser timezone 무관하게 UTC 시간으로 KST 도출.
+  const kstMs = now.getTime() + 9 * 60 * 60 * 1000;
+  const kst = new Date(kstMs);
+  const day = kst.getUTCDay(); // 0=Sun, 6=Sat
+  if (day === 0 || day === 6) return false;
+  const minutes = kst.getUTCHours() * 60 + kst.getUTCMinutes();
+  return minutes >= 9 * 60 && minutes <= 15 * 60 + 30;
 }
+
+export function useKoreanSnapshotPolling(symbol: string | null | undefined): PriceUpdate | null {
+  // FORK (#33): hook 자체가 KR 검사 — 호출자는 그냥 selectedStock 넘기면 됨.
+  // KR 외 symbol 은 query disabled 로 idle (no fetch, no PriceUpdate).
+  const enabled = !!symbol && isKoreanSymbol(symbol);
+
+  const { data } = useQuery({
+    queryKey: ['marketview', 'krSnapshot', symbol],
+    queryFn: ({ signal }) => fetchSnapshot(symbol as string, { signal }),
+    enabled,
+    refetchInterval: () => (isKRMarketOpen() ? OPEN_INTERVAL_MS : CLOSED_INTERVAL_MS),
+    // 탭이 background 면 폴링 중단 — visibilitychange 시 자동 resume.
+    refetchIntervalInBackground: false,
+    staleTime: 30_000,
+    retry: 1,
+  });
+
+  if (!enabled || !data) return null;
+
+  const close = data.price ?? 0;
+  const prev = data.previous_close ?? 0;
+  const change = data.change ?? (prev ? close - prev : 0);
+  const pct = data.change_percent ?? (prev ? (change / prev) * 100 : 0);
+  const open = data.open ?? 0;
+  const high = data.high ?? 0;
+  const low = data.low ?? 0;
+  const volume = data.volume ?? 0;
+
+  return {
+    symbol: data.symbol || (symbol as string),
+    price: close,
+    open,
+    high,
+    low,
+    close,
+    volume,
+    change,
+    changePercent: pct,
+    timestamp: Date.now(),
+    barData: {
+      time: Math.floor(Date.now() / 1000),
+      open,
+      high,
+      low,
+      close,
+      volume,
+    },
+  };
+}
+
+// 테스트용 export — KR 정규장 시간 검사 자체 검증.
+export const __test_isKRMarketOpen = isKRMarketOpen;


### PR DESCRIPTION
## 요약
Closes #33 (backend slice — frontend slice 는 PR #41 에서 머지 완료, KR fundamentals 채우기는 #42 로 분리)

KR 사용자가 005930.KS 선택 시 차트가 정상 채워지고 fundamentals 카드가 명확한 안내 메시지를 표시. 단일 사용자 self-hosted production 컨텍스트에 맞춘 minimum-viable 구현.

## 옵션 결정
| 옵션 | 평가 |
|---|---|
| A: ginlix-data plan 업그레이드 | self-hosted 철학 모순, 외부 종속 → ❌ |
| B: KoreanWebSocketSource 신규 (한투/키움) | 1인 production 에 oversized, OAuth 부담 → ❌ |
| **C: polling fallback** | 단일 사용자 traffic 미미, pykrx 이미 동작 → ✅ |

## 변경 사항

### Backend
- `src/server/models/market_data.py`: `CompanyOverviewResponse` / `AnalystDataResponse` 에 `unsupported: bool = False` + `message: Optional[str]` 필드 (default False 라 backward-compat)
- `src/server/app/market_data.py`: `/stocks/{symbol}/overview` 와 `/stocks/{symbol}/analyst-data` 가 KR ticker (.KS / .KQ) 검출 시 200 with `unsupported=True` 응답. 모든 데이터 필드는 None
- `tests/unit/server/app/test_market_data_kr_unsupported.py` (신규): KR 분기 5개 케이스

### Frontend
- `web/src/lib/marketTimezone.ts`: `isKoreanSymbol(symbol)` helper — KR 분기 단일 진리. 단위 테스트 4개 케이스 추가
- `web/src/pages/MarketView/hooks/useKoreanSnapshotPolling.ts` (신규): 60s `fetchSnapshot` polling. PriceUpdate 형태로 변환해 기존 displayPrice 와 호환. KR 외 symbol 이면 no-op
- `MarketView.tsx`: `isKR` 분기 — KR 시 `wsSubscribe` skip + `krPollPrice` 사용. US 는 기존 WS 그대로
- `CompanyOverviewPanel.tsx`: `data.unsupported === true` 면 안내 카드만 단독 렌더, 차트들 모두 skip

## 기술적 판단
- **왜 backend `unsupported` 필드 추가 (404 / 422 가 아닌)?**: 422 면 frontend 가 에러 처리해야 함 — 의도적 "미지원" 과 "진짜 에러" 구분 어려움. 200 with explicit flag 가 graceful + 명시적
- **왜 polling 60s?**: KR 정규장 09:00–15:30 짧음, 단일 사용자라 traffic 미미, dashboard 모니터링 lag 으로 충분
- **`isKoreanSymbol` helper 분리 이유**: backend `endswith((.KS, .KQ))` 와 frontend `regex /\.(KS|KQ)$/i` 가 같은 의미를 다른 위치에서 정의. helper 로 frontend 단일화 + backend 도 향후 같은 위치에서 import 가능 (별도 PR 에서 통합 고려)

## 검증
- `uv run pytest tests/unit/server/app/test_market_data_kr_unsupported.py tests/unit/data_client/ -q` → 158/158 통과 (5개 신규)
- `pnpm vitest run` → 574/574 통과 (4개 신규)
- `pnpm lint`, `uv run ruff check` → 0 errors
- 수동 검증 권장: dev server 띄워 005930.KS 선택 → 차트 (60s 갱신) + fundamentals 카드 안내 표시 확인

## 의존
- 본 PR 머지 후 #42 (KR fundamentals via pykrx + DART) 진행 가능

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **새로운 기능**
  * 한국 시장 종목(KOSPI, KOSDAQ)의 가격 정보 폴링 방식 업데이트 추가
  * 한국 시장에서 조회 불가능한 회사 개요 및 애널리스트 데이터에 대한 명확한 상태 안내 메시지 제공

<!-- end of auto-generated comment: release notes by coderabbit.ai -->