### PR TITLE
feat: KR fundamentals Stage A+B — pykrx performance + yfinance quote (#42)

### DIFF
--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -162,6 +162,9 @@ class KoreanFundamentalsSource:
 
         외부 호출 (yfinance + pykrx) 은 ``asyncio.to_thread`` 로 wrap.
         """
+        # FORK (#42): supports() / is_unsupported_analyst_market 와 동일하게 strip 먼저.
+        # 호출자가 이미 normalize 했더라도 source 자체가 raw input 안전 처리.
+        symbol = symbol.strip()
         ticker = _strip_suffix(symbol)
         symbol_upper = symbol.upper()
 

--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -107,7 +107,9 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
         logger.warning("kr_fundamentals.pykrx_ohlcv.failed | ticker=%s", ticker, exc_info=True)
         return {p: None for p in (*_PERIOD_BUSINESS_DAYS.keys(), "YTD")}
 
-    if df is None or df.empty:
+    # FORK (#42): "종가" column 누락 (pykrx 응답 schema 변경 / mock 결함) 도 빈 응답으로
+    # 안전 처리 — 직접 인덱싱은 KeyError 로 /overview 전체 500 으로 번질 수 있음.
+    if df is None or df.empty or "종가" not in df.columns:
         return {p: None for p in (*_PERIOD_BUSINESS_DAYS.keys(), "YTD")}
 
     closes = df["종가"]
@@ -152,7 +154,8 @@ class KoreanFundamentalsSource:
 
     @staticmethod
     def supports(symbol: str) -> bool:
-        return symbol.upper().endswith(_KR_SUFFIXES)
+        # is_unsupported_analyst_market / _is_kr_symbol 와 동일하게 strip + upper 정규화.
+        return symbol.strip().upper().endswith(_KR_SUFFIXES)
 
     async def get_overview(self, symbol: str) -> dict[str, Any]:
         """Return CompanyOverviewResponse 호환 dict (KR 채울 수 있는 부분만).

--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -1,0 +1,193 @@
+"""KR fundamentals — quote enrichment + performance for KOSPI/KOSDAQ tickers.
+
+FORK (#42 Stage A+B):
+* Quote (시가총액 / 52W / dayHigh-Low / shares): yfinance ``fast_info`` 사용.
+  pykrx 의 ``get_market_fundamental`` / ``get_market_cap`` 은 KRX 사이트 응답
+  구조 변경으로 현재 KeyError 발생 — yfinance fast_info 가 KR ticker 도 안정적
+  으로 처리.
+* Performance (1D / 5D / 1M / 3M / 6M / 1Y / YTD %): pykrx OHLCV 로 계산.
+  pykrx 의 일별 종가 endpoint 는 정상 동작.
+* PER / PBR / EPS / 배당: 본 source 에서는 미채움 (yf ``info`` 느려 timeout
+  위험. DART 분기 보고서 기반은 별도 issue).
+* analystRatings / quarterlyFundamentals / cashFlow / revenueByProduct/Geo:
+  별도 issue (DART 분기 사업보고서 파싱) 로 분리.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+from datetime import datetime, timedelta
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import yfinance as yf
+from pykrx import stock
+
+logger = logging.getLogger(__name__)
+
+_KST = ZoneInfo("Asia/Seoul")
+_KR_SUFFIXES = (".KS", ".KQ")
+
+# Performance bar 가 채울 기간 (영업일 lookback). YTD 는 별도 — 연초부터.
+_PERIOD_BUSINESS_DAYS: dict[str, int] = {
+    "1D": 1,
+    "5D": 5,
+    "1M": 22,    # 월 평균 거래일
+    "3M": 66,
+    "6M": 132,
+    "1Y": 252,
+}
+
+
+def _strip_suffix(symbol: str) -> str:
+    upper = symbol.upper()
+    for suffix in _KR_SUFFIXES:
+        if upper.endswith(suffix):
+            return symbol[: -len(suffix)]
+    return symbol
+
+
+def _safe_float(value: Any) -> float | None:
+    """Coerce to float, returning None for NaN / None / non-numeric."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    return f
+
+
+def _fetch_quote_from_yf(yahoo_symbol: str) -> dict[str, Any]:
+    """yfinance fast_info 로 quote 도출. 호출 실패 시 빈 dict (caller 가 partial 응답 OK)."""
+    try:
+        ticker = yf.Ticker(yahoo_symbol)
+        fi = ticker.fast_info
+        last = _safe_float(fi.get("lastPrice"))
+        prev = _safe_float(fi.get("previousClose"))
+        change = (last - prev) if (last is not None and prev is not None and prev != 0) else None
+        change_pct = (change / prev * 100) if (change is not None and prev) else None
+        shares = _safe_float(fi.get("shares"))
+        return {
+            "price": last,
+            "change": change,
+            "changePct": change_pct,
+            "open": _safe_float(fi.get("open")),
+            "previousClose": prev,
+            "dayLow": _safe_float(fi.get("dayLow")),
+            "dayHigh": _safe_float(fi.get("dayHigh")),
+            "yearLow": _safe_float(fi.get("yearLow")),
+            "yearHigh": _safe_float(fi.get("yearHigh")),
+            "volume": _safe_float(fi.get("lastVolume")),
+            "marketCap": _safe_float(fi.get("marketCap")),
+            "shares": shares,
+            # 본 PR 에서 채우지 않음 — DART/yf info 통합 별도 PR.
+            "pe": None,
+            "eps": None,
+        }
+    except Exception:
+        logger.warning("kr_fundamentals.yf_quote.failed | symbol=%s", yahoo_symbol, exc_info=True)
+        return {}
+
+
+def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
+    """pykrx OHLCV 로 7개 period % 계산. 거래일 부족 시 해당 period 만 None."""
+    today_kst = datetime.now(_KST)
+    # 1Y + 여유 30일 lookback — 252 영업일 + 휴일 buffer.
+    start_date = today_kst - timedelta(days=int(252 * 1.6))
+    start = start_date.strftime("%Y%m%d")
+    end = today_kst.strftime("%Y%m%d")
+
+    try:
+        df = stock.get_market_ohlcv(start, end, ticker)
+    except Exception:
+        logger.warning("kr_fundamentals.pykrx_ohlcv.failed | ticker=%s", ticker, exc_info=True)
+        return {p: None for p in (*_PERIOD_BUSINESS_DAYS.keys(), "YTD")}
+
+    if df is None or df.empty:
+        return {p: None for p in (*_PERIOD_BUSINESS_DAYS.keys(), "YTD")}
+
+    closes = df["종가"]
+    last_close = _safe_float(closes.iloc[-1])
+    if last_close is None or last_close == 0:
+        return {p: None for p in (*_PERIOD_BUSINESS_DAYS.keys(), "YTD")}
+
+    perf: dict[str, float | None] = {}
+    for label, lookback_bd in _PERIOD_BUSINESS_DAYS.items():
+        # iloc[-1] 이 today, 그 이전 lookback_bd 번째 종가와 비교.
+        if len(closes) <= lookback_bd:
+            perf[label] = None
+            continue
+        ref = _safe_float(closes.iloc[-1 - lookback_bd])
+        if ref is None or ref == 0:
+            perf[label] = None
+            continue
+        perf[label] = round((last_close - ref) / ref * 100, 4)
+
+    # YTD: 올해 첫 거래일 종가 기준.
+    year = today_kst.year
+    ytd_mask = df.index.year == year
+    if ytd_mask.any():
+        ytd_first = _safe_float(df[ytd_mask]["종가"].iloc[0])
+        perf["YTD"] = (
+            round((last_close - ytd_first) / ytd_first * 100, 4)
+            if ytd_first
+            else None
+        )
+    else:
+        perf["YTD"] = None
+
+    return perf
+
+
+class KoreanFundamentalsSource:
+    """quote + performance for KR ticker (.KS / .KQ).
+
+    분기 사업보고서 기반 quarterlyFundamentals / cashFlow / revenueByProduct/Geo
+    는 별도 source (DART 통합 — issue #42 Stage C) 로 분리.
+    """
+
+    @staticmethod
+    def supports(symbol: str) -> bool:
+        return symbol.upper().endswith(_KR_SUFFIXES)
+
+    async def get_overview(self, symbol: str) -> dict[str, Any]:
+        """Return CompanyOverviewResponse 호환 dict (KR 채울 수 있는 부분만).
+
+        외부 호출 (yfinance + pykrx) 은 ``asyncio.to_thread`` 로 wrap.
+        """
+        ticker = _strip_suffix(symbol)
+        symbol_upper = symbol.upper()
+
+        quote, performance = await asyncio.gather(
+            asyncio.to_thread(_fetch_quote_from_yf, symbol_upper),
+            asyncio.to_thread(_fetch_performance_from_pykrx, ticker),
+        )
+
+        # quote 가 비었으면 unsupported 와 동일 — caller 가 unsupported flag 다시 세움.
+        if not quote:
+            return {
+                "symbol": symbol_upper,
+                "name": None,
+                "quote": None,
+                "performance": None,
+                "_partial": True,
+            }
+
+        # name 은 yfinance fast_info 에 없음. Ticker.info 는 비싸서 생략 — 별도 PR.
+        return {
+            "symbol": symbol_upper,
+            "name": None,
+            "quote": quote,
+            "performance": performance,
+            # 본 PR 에서 채우지 않음 — DART 통합 별도 PR.
+            "analystRatings": None,
+            "quarterlyFundamentals": None,
+            "earningsSurprises": None,
+            "cashFlow": None,
+            "revenueByProduct": None,
+            "revenueByGeo": None,
+        }

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -45,20 +45,27 @@ router = APIRouter(
 )
 
 
-# FORK (#33): /analyst-data 가 native source 가 없는 시장의 ticker 를 받았을 때
-# graceful "미지원" 응답으로 처리. 향후 .HK / .T 등 추가 시 본 set 에 추가.
-# (KR /overview 는 #42 Stage A+B 에서 KoreanFundamentalsSource 가 채움 — 별도 분기.)
-_UNSUPPORTED_ANALYST_SUFFIXES: tuple[str, ...] = (".KS", ".KQ")
+# FORK (#33 / #42): KR ticker (.KS / .KQ) 단일 진리. 향후 시장 분기 (예: .HK)
+# 추가 시 본 tuple 만 갱신 — is_unsupported_analyst_market / _is_kr_symbol 둘 다 참조.
+KR_SUFFIXES: tuple[str, ...] = (".KS", ".KQ")
 
 
 def is_unsupported_analyst_market(symbol: str) -> bool:
-    """Return True if symbol's market lacks a native analyst-rating source."""
-    return symbol.strip().upper().endswith(_UNSUPPORTED_ANALYST_SUFFIXES)
+    """Return True if symbol's market lacks a native analyst-rating source.
+
+    현재 KR (.KS / .KQ) 만 unsupported — analyst rating 의 native KR source 가 없음.
+    """
+    return symbol.strip().upper().endswith(KR_SUFFIXES)
 
 
 def _is_kr_symbol(symbol: str) -> bool:
     """Return True if symbol is a KR (.KS / .KQ) ticker — for /overview routing."""
-    return symbol.strip().upper().endswith((".KS", ".KQ"))
+    return symbol.strip().upper().endswith(KR_SUFFIXES)
+
+
+# FORK (#42): source 일시 outage 시 _partial fallback 응답을 짧게 캐시 — 매 요청
+# 마다 yf 재호출 방지. 성공 캐시 (5분) 보다 짧아 outage 회복 시 빠르게 정상화.
+_NEGATIVE_CACHE_TTL_SECONDS = 60
 
 
 def _convert_data_points(raw_data: list) -> list[IntradayDataPoint]:
@@ -511,12 +518,19 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
             kr_source = KoreanFundamentalsSource()
             artifact = await kr_source.get_overview(symbol_upper)
             if artifact.get("_partial"):
-                # quote 도출 실패 — graceful unsupported 와 동일 처리.
-                return CompanyOverviewResponse(
+                # quote 도출 실패 — graceful unsupported. 짧은 negative cache 로
+                # source outage 시 burst 보호 (60s, 성공 5분보다 짧음).
+                partial_response = CompanyOverviewResponse(
                     symbol=symbol_upper,
                     unsupported=True,
                     message="KR market data temporarily unavailable.",
                 )
+                await cache.set(
+                    cache_key,
+                    partial_response.model_dump(),
+                    ttl=_NEGATIVE_CACHE_TTL_SECONDS,
+                )
+                return partial_response
             response = CompanyOverviewResponse(
                 symbol=artifact["symbol"],
                 name=artifact.get("name"),

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -547,11 +547,19 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
             return response
         except Exception as e:
             logger.error(f"KoreanFundamentalsSource failed for {symbol_upper}: {e}")
-            return CompanyOverviewResponse(
+            # FORK (#42): exception 분기도 _partial 와 동일하게 negative cache (60s)
+            # 로 burst 보호 — yf/pykrx outage 시 매 요청마다 외부 source 재호출 방지.
+            error_response = CompanyOverviewResponse(
                 symbol=symbol_upper,
                 unsupported=True,
                 message="KR market data temporarily unavailable.",
             )
+            await cache.set(
+                cache_key,
+                error_response.model_dump(),
+                ttl=_NEGATIVE_CACHE_TTL_SECONDS,
+            )
+            return error_response
 
     try:
         from src.utils.cache.redis_cache import get_cache_client

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -45,20 +45,20 @@ router = APIRouter(
 )
 
 
-# FORK (#33): /overview, /analyst-data 가 native source 가 없는 시장의 ticker
-# 를 받았을 때 graceful "미지원" 응답으로 처리. 향후 .HK / .T 등 추가 시 본 set
-# 에 추가하면 모든 endpoint 가 일관되게 동작. fundamentals 가 native 로 채워진
-# 시장 (예: KR via #42 pykrx + DART) 은 set 에서 제외.
-_UNSUPPORTED_FUNDAMENTALS_SUFFIXES: tuple[str, ...] = (".KS", ".KQ")
+# FORK (#33): /analyst-data 가 native source 가 없는 시장의 ticker 를 받았을 때
+# graceful "미지원" 응답으로 처리. 향후 .HK / .T 등 추가 시 본 set 에 추가.
+# (KR /overview 는 #42 Stage A+B 에서 KoreanFundamentalsSource 가 채움 — 별도 분기.)
+_UNSUPPORTED_ANALYST_SUFFIXES: tuple[str, ...] = (".KS", ".KQ")
 
 
-def is_unsupported_market(symbol: str) -> bool:
-    """Return True if symbol's market lacks a native fundamentals source.
+def is_unsupported_analyst_market(symbol: str) -> bool:
+    """Return True if symbol's market lacks a native analyst-rating source."""
+    return symbol.strip().upper().endswith(_UNSUPPORTED_ANALYST_SUFFIXES)
 
-    Symbol is normalized to upper-case before suffix check, matching the
-    handler's own normalization (``symbol.strip().upper()``).
-    """
-    return symbol.strip().upper().endswith(_UNSUPPORTED_FUNDAMENTALS_SUFFIXES)
+
+def _is_kr_symbol(symbol: str) -> bool:
+    """Return True if symbol is a KR (.KS / .KQ) ticker — for /overview routing."""
+    return symbol.strip().upper().endswith((".KS", ".KQ"))
 
 
 def _convert_data_points(raw_data: list) -> list[IntradayDataPoint]:
@@ -494,15 +494,50 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
 
     symbol_upper = symbol.strip().upper()
 
-    # FORK (#33): native fundamentals source 가 없는 시장은 graceful 미지원 응답.
-    # message 는 영어 fallback — frontend 가 i18n 키 (marketView.fundamentalsUnsupported)
-    # 로 사용자 locale 에 맞게 표시.
-    if is_unsupported_market(symbol_upper):
-        return CompanyOverviewResponse(
-            symbol=symbol_upper,
-            unsupported=True,
-            message="Fundamentals are not yet supported for this market.",
-        )
+    # FORK (#42 Stage A+B): KR ticker 는 KoreanFundamentalsSource 로 quote + performance
+    # 채움. quarterlyFundamentals / cashFlow / revenueByProduct 등은 본 stage 에서
+    # 미채움 (DART 통합 별도 PR). frontend 는 채워진 부분만 렌더, 나머지는 빈 상태.
+    if _is_kr_symbol(symbol_upper):
+        from src.utils.cache.redis_cache import get_cache_client
+        from src.data_client.korean.fundamentals_source import KoreanFundamentalsSource
+
+        cache = get_cache_client()
+        cache_key = f"overview:{symbol_upper}"
+        cached = await cache.get(cache_key)
+        if cached is not None:
+            return CompanyOverviewResponse(**cached)
+
+        try:
+            kr_source = KoreanFundamentalsSource()
+            artifact = await kr_source.get_overview(symbol_upper)
+            if artifact.get("_partial"):
+                # quote 도출 실패 — graceful unsupported 와 동일 처리.
+                return CompanyOverviewResponse(
+                    symbol=symbol_upper,
+                    unsupported=True,
+                    message="KR market data temporarily unavailable.",
+                )
+            response = CompanyOverviewResponse(
+                symbol=artifact["symbol"],
+                name=artifact.get("name"),
+                quote=artifact.get("quote"),
+                performance=artifact.get("performance"),
+                analystRatings=artifact.get("analystRatings"),
+                quarterlyFundamentals=artifact.get("quarterlyFundamentals"),
+                earningsSurprises=artifact.get("earningsSurprises"),
+                cashFlow=artifact.get("cashFlow"),
+                revenueByProduct=artifact.get("revenueByProduct"),
+                revenueByGeo=artifact.get("revenueByGeo"),
+            )
+            await cache.set(cache_key, response.model_dump(), ttl=300)
+            return response
+        except Exception as e:
+            logger.error(f"KoreanFundamentalsSource failed for {symbol_upper}: {e}")
+            return CompanyOverviewResponse(
+                symbol=symbol_upper,
+                unsupported=True,
+                message="KR market data temporarily unavailable.",
+            )
 
     try:
         from src.utils.cache.redis_cache import get_cache_client
@@ -563,7 +598,7 @@ async def get_analyst_data(
     symbol_upper = symbol.strip().upper()
 
     # FORK (#33): native analyst rating source 가 없는 시장은 graceful 미지원 응답.
-    if is_unsupported_market(symbol_upper):
+    if is_unsupported_analyst_market(symbol_upper):
         return AnalystDataResponse(
             symbol=symbol_upper,
             grades=[],

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -134,6 +134,17 @@ def test_performance_returns_all_none_on_empty_df(monkeypatch):
     assert all(v is None for v in perf.values())
 
 
+def test_performance_returns_all_none_when_close_column_missing(monkeypatch):
+    """pykrx schema 변경 / mock 결함으로 '종가' column 이 빠진 DataFrame 도 안전 처리.
+
+    회귀 방지 — 직접 df["종가"] 인덱싱은 KeyError 로 /overview 전체 500 으로 번짐.
+    """
+    df_no_close = pd.DataFrame({"시가": [100.0, 101.0], "거래량": [10, 20]})
+    monkeypatch.setattr(fs.stock, "get_market_ohlcv", lambda *a, **k: df_no_close)
+    perf = fs._fetch_performance_from_pykrx("005930")
+    assert all(v is None for v in perf.values())
+
+
 # ---------------------------------------------------------------------------
 # _safe_float — NaN / None / non-numeric 처리
 # ---------------------------------------------------------------------------

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -71,6 +71,31 @@ async def test_get_overview_returns_quote_and_performance(monkeypatch):
 
 
 @pytest.mark.asyncio
+async def test_get_overview_strips_whitespace_from_symbol(monkeypatch):
+    """공백 포함 호출 시 ticker / symbol_upper 모두 깨끗하게 정규화 — supports() 와 일관."""
+    captured: dict[str, str] = {}
+
+    def capture_quote(sym: str) -> dict[str, float]:
+        captured["yf_symbol"] = sym
+        return {"price": 1.0}
+
+    def capture_perf(ticker: str) -> dict[str, float]:
+        captured["pykrx_ticker"] = ticker
+        return {"1D": 0.0}
+
+    monkeypatch.setattr(fs, "_fetch_quote_from_yf", capture_quote)
+    monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", capture_perf)
+
+    source = fs.KoreanFundamentalsSource()
+    result = await source.get_overview("  005930.KS  ")
+
+    # symbol/ticker 모두 strip 됐는지 — 공백이 외부 호출까지 leak 안 돼야
+    assert captured["yf_symbol"] == "005930.KS"
+    assert captured["pykrx_ticker"] == "005930"
+    assert result["symbol"] == "005930.KS"
+
+
+@pytest.mark.asyncio
 async def test_get_overview_yf_fail_returns_partial(monkeypatch):
     """yf 호출 실패 (빈 dict) 면 _partial=True — caller 가 unsupported 응답으로 fallback."""
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: {})

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -1,0 +1,155 @@
+"""
+Tests for KoreanFundamentalsSource (issue #42 Stage A+B).
+
+External calls (yfinance fast_info, pykrx OHLCV) 은 module-level helper 로
+분리해뒀으니 monkeypatch 로 deterministic mock. integration 검증 (실제 yf/pykrx
+hit) 은 별도 (외부 의존이라 unit suite 에 포함 안 함).
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+import pytest
+
+from src.data_client.korean import fundamentals_source as fs
+
+
+# ---------------------------------------------------------------------------
+# supports() — 정적 가드
+# ---------------------------------------------------------------------------
+
+class TestSupports:
+    def test_kospi_kosdaq(self):
+        assert fs.KoreanFundamentalsSource.supports("005930.KS") is True
+        assert fs.KoreanFundamentalsSource.supports("263750.KQ") is True
+
+    def test_case_insensitive(self):
+        assert fs.KoreanFundamentalsSource.supports("005930.ks") is True
+
+    def test_us_or_other_false(self):
+        assert fs.KoreanFundamentalsSource.supports("GOOGL") is False
+        assert fs.KoreanFundamentalsSource.supports("0700.HK") is False
+
+
+# ---------------------------------------------------------------------------
+# get_overview() — quote + performance 통합
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_get_overview_returns_quote_and_performance(monkeypatch):
+    """yf + pykrx 정상 응답 시 quote + performance 합쳐진 dict 반환."""
+    fake_quote = {
+        "price": 75000.0,
+        "change": 500.0,
+        "changePct": 0.67,
+        "open": 74500.0,
+        "previousClose": 74500.0,
+        "dayLow": 74400.0,
+        "dayHigh": 75200.0,
+        "yearLow": 60000.0,
+        "yearHigh": 88000.0,
+        "volume": 12_000_000.0,
+        "marketCap": 500_000_000_000_000.0,
+        "shares": 6_700_000_000.0,
+        "pe": None,
+        "eps": None,
+    }
+    fake_perf = {"1D": 0.67, "5D": 1.5, "1M": 3.2, "3M": -2.1, "6M": 5.0, "1Y": 25.0, "YTD": 10.0}
+
+    monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: fake_quote)
+    monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: fake_perf)
+
+    source = fs.KoreanFundamentalsSource()
+    result = await source.get_overview("005930.KS")
+
+    assert result["symbol"] == "005930.KS"
+    assert result["quote"] == fake_quote
+    assert result["performance"] == fake_perf
+    # 본 stage 에서 채우지 않는 필드는 None — frontend 가 빈 카드 안전 렌더
+    assert result["analystRatings"] is None
+    assert result["quarterlyFundamentals"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_overview_yf_fail_returns_partial(monkeypatch):
+    """yf 호출 실패 (빈 dict) 면 _partial=True — caller 가 unsupported 응답으로 fallback."""
+    monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: {})
+    monkeypatch.setattr(
+        fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 1.0}
+    )
+
+    source = fs.KoreanFundamentalsSource()
+    result = await source.get_overview("005930.KS")
+
+    assert result["_partial"] is True
+    assert result["quote"] is None
+    assert result["performance"] is None
+
+
+# ---------------------------------------------------------------------------
+# _fetch_performance_from_pykrx() — % 계산 logic
+# ---------------------------------------------------------------------------
+
+def _make_ohlcv_df(closes: list[float], freq: str = "B") -> pd.DataFrame:
+    """Mock pykrx OHLCV DataFrame — '종가' column 만 채움 (계산에 충분)."""
+    idx = pd.date_range(end="2026-04-27", periods=len(closes), freq=freq, name="날짜")
+    return pd.DataFrame({"종가": closes}, index=idx)
+
+
+def test_performance_computes_percentage_against_lookback(monkeypatch):
+    # 마지막 종가 100, 1일 전 99, 5일 전 95 → 1D=1.01%, 5D=5.26%
+    # 1Y lookback 은 252 영업일이라 총 260+ bars 필요.
+    closes = [80.0] * 260 + [95.0, 96.0, 97.0, 98.0, 99.0, 100.0]
+    monkeypatch.setattr(fs.stock, "get_market_ohlcv", lambda *a, **k: _make_ohlcv_df(closes))
+
+    perf = fs._fetch_performance_from_pykrx("005930")
+    assert perf["1D"] == pytest.approx((100 - 99) / 99 * 100, abs=0.01)
+    assert perf["5D"] == pytest.approx((100 - 95) / 95 * 100, abs=0.01)
+    assert perf["1Y"] is not None  # 252+ bars 있음
+
+
+def test_performance_returns_none_when_insufficient_data(monkeypatch):
+    # 짧은 시계열 — 1D 만 가능, 나머지는 None
+    monkeypatch.setattr(
+        fs.stock, "get_market_ohlcv", lambda *a, **k: _make_ohlcv_df([100.0, 101.0])
+    )
+    perf = fs._fetch_performance_from_pykrx("005930")
+    assert perf["1D"] == pytest.approx((101 - 100) / 100 * 100, abs=0.01)
+    assert perf["1M"] is None
+    assert perf["1Y"] is None
+
+
+def test_performance_returns_all_none_on_pykrx_failure(monkeypatch):
+    def boom(*args, **kwargs):
+        raise RuntimeError("KRX site down")
+
+    monkeypatch.setattr(fs.stock, "get_market_ohlcv", boom)
+    perf = fs._fetch_performance_from_pykrx("005930")
+    assert all(v is None for v in perf.values())
+
+
+def test_performance_returns_all_none_on_empty_df(monkeypatch):
+    monkeypatch.setattr(fs.stock, "get_market_ohlcv", lambda *a, **k: pd.DataFrame())
+    perf = fs._fetch_performance_from_pykrx("005930")
+    assert all(v is None for v in perf.values())
+
+
+# ---------------------------------------------------------------------------
+# _safe_float — NaN / None / non-numeric 처리
+# ---------------------------------------------------------------------------
+
+class TestSafeFloat:
+    def test_valid_numeric(self):
+        assert fs._safe_float(1.5) == 1.5
+        assert fs._safe_float(0) == 0.0
+        assert fs._safe_float("3.14") == 3.14
+
+    def test_none_returns_none(self):
+        assert fs._safe_float(None) is None
+
+    def test_nan_returns_none(self):
+        assert fs._safe_float(float("nan")) is None
+
+    def test_non_numeric_returns_none(self):
+        assert fs._safe_float("abc") is None
+        assert fs._safe_float({}) is None

--- a/tests/unit/server/app/test_market_data_kr_unsupported.py
+++ b/tests/unit/server/app/test_market_data_kr_unsupported.py
@@ -1,19 +1,23 @@
 """
-Tests for /analyst-data graceful 미지원 응답 (issue #33 backend slice).
+Tests for /analyst-data 미지원 응답 + /overview KR router-level 통합.
 
-KR ticker (.KS / .KQ) 호출 시 200 with unsupported=True 로 응답. user_id / DB /
-cache 모두 무관 (early-return 분기) 이라 mock 없이 직접 함수 호출.
-
-NOTE: /overview KR 분기는 #42 Stage A+B 에서 KoreanFundamentalsSource 로 채워짐
-(test_kr_fundamentals_source.py 참조).
+- /analyst-data 는 KR ticker 호출 시 200 with unsupported=True (helper 직접 호출).
+- /overview KR 분기는 #42 에서 KoreanFundamentalsSource 호출 — router 레벨로
+  AsyncClient + ASGITransport 통합 검증 (FastAPI dependency / response 직렬화 포함).
+- KoreanFundamentalsSource 자체 단위는 test_fundamentals_source.py 참조.
 """
 
+from unittest.mock import AsyncMock, patch
+
 import pytest
+import pytest_asyncio
+from httpx import ASGITransport, AsyncClient
 
 from src.server.app.market_data import (
     get_analyst_data,
     is_unsupported_analyst_market,
 )
+from tests.conftest import create_test_app
 
 
 class TestIsUnsupportedAnalystMarket:
@@ -48,3 +52,83 @@ class TestAnalystDataKRUnsupported:
     async def test_kosdaq_ticker_returns_unsupported(self):
         result = await get_analyst_data(symbol="263750.KQ", user_id="test-user")
         assert result.unsupported is True
+
+
+# ---------------------------------------------------------------------------
+# Router-level 통합 — /overview KR 분기 (FastAPI dependency / 직렬화 검증)
+# ---------------------------------------------------------------------------
+
+
+@pytest_asyncio.fixture
+async def overview_client():
+    from src.server.app.market_data import router
+
+    app = create_test_app(router)
+    async with AsyncClient(
+        transport=ASGITransport(app=app), base_url="http://test"
+    ) as c:
+        yield c
+
+
+@pytest.mark.asyncio
+async def test_overview_router_kr_success(overview_client):
+    """KoreanFundamentalsSource 가 정상 응답 시 quote + performance 포함된 200 응답."""
+    artifact = {
+        "symbol": "005930.KS",
+        "name": None,
+        "quote": {
+            "price": 75000.0, "change": 500.0, "changePct": 0.67,
+            "marketCap": 500_000_000_000_000.0, "yearHigh": 88000.0,
+        },
+        "performance": {"1D": 0.67, "5D": 1.5, "1M": 3.2, "3M": -2.1, "6M": 5.0, "1Y": 25.0, "YTD": 10.0},
+        "analystRatings": None,
+        "quarterlyFundamentals": None,
+        "earningsSurprises": None,
+        "cashFlow": None,
+        "revenueByProduct": None,
+        "revenueByGeo": None,
+    }
+    cache_mock = AsyncMock()
+    cache_mock.get = AsyncMock(return_value=None)  # cache miss
+    cache_mock.set = AsyncMock(return_value=True)
+
+    with patch(
+        "src.data_client.korean.fundamentals_source.KoreanFundamentalsSource.get_overview",
+        new=AsyncMock(return_value=artifact),
+    ), patch(
+        "src.utils.cache.redis_cache.get_cache_client", return_value=cache_mock,
+    ):
+        resp = await overview_client.get("/api/v1/market-data/stocks/005930.KS/overview")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["symbol"] == "005930.KS"
+    assert body["unsupported"] is False
+    assert body["quote"]["marketCap"] == 500_000_000_000_000.0
+    assert body["performance"]["1Y"] == 25.0
+
+
+@pytest.mark.asyncio
+async def test_overview_router_kr_partial_falls_back_to_unsupported(overview_client):
+    """KoreanFundamentalsSource 가 _partial=True 반환 시 unsupported 응답 + negative cache 기록."""
+    cache_mock = AsyncMock()
+    cache_mock.get = AsyncMock(return_value=None)
+    cache_mock.set = AsyncMock(return_value=True)
+
+    with patch(
+        "src.data_client.korean.fundamentals_source.KoreanFundamentalsSource.get_overview",
+        new=AsyncMock(return_value={"symbol": "005930.KS", "_partial": True, "quote": None, "performance": None}),
+    ), patch(
+        "src.utils.cache.redis_cache.get_cache_client", return_value=cache_mock,
+    ):
+        resp = await overview_client.get("/api/v1/market-data/stocks/005930.KS/overview")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["unsupported"] is True
+    assert body["message"] is not None
+    assert "unavailable" in body["message"].lower()
+    # negative cache 기록 검증 — TTL 60s 로 burst 보호
+    cache_mock.set.assert_awaited_once()
+    _, kwargs = cache_mock.set.call_args
+    assert kwargs.get("ttl") == 60

--- a/tests/unit/server/app/test_market_data_kr_unsupported.py
+++ b/tests/unit/server/app/test_market_data_kr_unsupported.py
@@ -132,3 +132,32 @@ async def test_overview_router_kr_partial_falls_back_to_unsupported(overview_cli
     cache_mock.set.assert_awaited_once()
     _, kwargs = cache_mock.set.call_args
     assert kwargs.get("ttl") == 60
+
+
+@pytest.mark.asyncio
+async def test_overview_router_kr_exception_falls_back_with_negative_cache(overview_client):
+    """KoreanFundamentalsSource 가 예외 raise 시 unsupported 응답 + negative cache 기록.
+
+    회귀 방지 — 이전엔 exception 분기에서 cache.set 누락돼 outage 시 매 요청마다 외부
+    source 재호출. _partial 와 동일하게 60s TTL 로 burst 보호.
+    """
+    cache_mock = AsyncMock()
+    cache_mock.get = AsyncMock(return_value=None)
+    cache_mock.set = AsyncMock(return_value=True)
+
+    with patch(
+        "src.data_client.korean.fundamentals_source.KoreanFundamentalsSource.get_overview",
+        new=AsyncMock(side_effect=Exception("yf upstream timeout")),
+    ), patch(
+        "src.utils.cache.redis_cache.get_cache_client", return_value=cache_mock,
+    ):
+        resp = await overview_client.get("/api/v1/market-data/stocks/005930.KS/overview")
+
+    assert resp.status_code == 200
+    body = resp.json()
+    assert body["unsupported"] is True
+    assert body["message"] is not None
+    assert "unavailable" in body["message"].lower()
+    cache_mock.set.assert_awaited_once()
+    _, kwargs = cache_mock.set.call_args
+    assert kwargs.get("ttl") == 60

--- a/tests/unit/server/app/test_market_data_kr_unsupported.py
+++ b/tests/unit/server/app/test_market_data_kr_unsupported.py
@@ -1,65 +1,37 @@
 """
-Tests for /overview, /analyst-data graceful 미지원 응답 (issue #33 backend slice).
+Tests for /analyst-data graceful 미지원 응답 (issue #33 backend slice).
 
-KR ticker (.KS / .KQ) 호출 시 200 with unsupported=True 로 응답해야 함 — frontend
-가 graceful "한국 시장 미지원" 카드 렌더할 수 있도록. user_id / DB / cache 모두
-무관 (early-return 분기) 이라 mock 없이 직접 함수 호출.
+KR ticker (.KS / .KQ) 호출 시 200 with unsupported=True 로 응답. user_id / DB /
+cache 모두 무관 (early-return 분기) 이라 mock 없이 직접 함수 호출.
+
+NOTE: /overview KR 분기는 #42 Stage A+B 에서 KoreanFundamentalsSource 로 채워짐
+(test_kr_fundamentals_source.py 참조).
 """
 
 import pytest
 
 from src.server.app.market_data import (
     get_analyst_data,
-    get_company_overview,
-    is_unsupported_market,
+    is_unsupported_analyst_market,
 )
 
 
-class TestIsUnsupportedMarket:
-    """Helper 직접 검증 — overview/analyst 외 endpoint 가 추후 같은 helper 쓸 수 있도록."""
+class TestIsUnsupportedAnalystMarket:
+    """Helper 직접 검증 — analyst 외 endpoint 가 추후 같은 helper 쓸 수 있도록."""
 
     def test_kospi_kosdaq_suffixes(self):
-        assert is_unsupported_market("005930.KS") is True
-        assert is_unsupported_market("263750.KQ") is True
+        assert is_unsupported_analyst_market("005930.KS") is True
+        assert is_unsupported_analyst_market("263750.KQ") is True
 
     def test_case_insensitive_via_normalize(self):
         # helper 자체가 strip + upper 처리 — handler 와 동일한 normalize 보장
-        assert is_unsupported_market("005930.ks") is True
-        assert is_unsupported_market("  263750.kq  ") is True
+        assert is_unsupported_analyst_market("005930.ks") is True
+        assert is_unsupported_analyst_market("  263750.kq  ") is True
 
     def test_us_and_unknown_are_supported(self):
-        assert is_unsupported_market("GOOGL") is False
-        assert is_unsupported_market("AAPL") is False
-        assert is_unsupported_market("0700.HK") is False  # 향후 추가 시 본 케이스 갱신
-
-
-class TestCompanyOverviewKRUnsupported:
-    @pytest.mark.asyncio
-    async def test_kospi_ticker_returns_unsupported(self):
-        result = await get_company_overview(symbol="005930.KS", user_id="test-user")
-        assert result.symbol == "005930.KS"
-        assert result.unsupported is True
-        # message 는 영어 fallback — frontend 가 i18n key 로 사용자 locale 에 맞게 표시.
-        assert result.message is not None
-        assert "supported" in result.message.lower()
-        # 모든 데이터 필드는 None — frontend 가 안전하게 빈 카드 렌더
-        assert result.quote is None
-        assert result.performance is None
-        assert result.quarterlyFundamentals is None
-
-    @pytest.mark.asyncio
-    async def test_kosdaq_ticker_returns_unsupported(self):
-        result = await get_company_overview(symbol="263750.KQ", user_id="test-user")
-        assert result.unsupported is True
-        assert result.symbol == "263750.KQ"
-
-    @pytest.mark.asyncio
-    async def test_lowercase_kr_suffix_returns_unsupported(self):
-        # symbol 은 backend 에서 strip().upper() 처리되므로 소문자/공백도 매칭.
-        # 반환되는 symbol 도 normalize 된 형태인지 검증 — 회귀 방지.
-        result = await get_company_overview(symbol="  005930.ks  ", user_id="test-user")
-        assert result.unsupported is True
-        assert result.symbol == "005930.KS"
+        assert is_unsupported_analyst_market("GOOGL") is False
+        assert is_unsupported_analyst_market("AAPL") is False
+        assert is_unsupported_analyst_market("0700.HK") is False  # 향후 추가 시 본 케이스 갱신
 
 
 class TestAnalystDataKRUnsupported:


### PR DESCRIPTION
## 요약
Refs #42 (Stage A+B; Stage C DART 통합은 후속 PR)

KR ticker (.KS / .KQ) 의 `/overview` 가 unsupported 카드 대신 시가총액 + performance 를 채워 표시. KR 사용자가 005930.KS 보면 차트 + 시가총액 + 1D/5D/1M/3M/6M/1Y/YTD %.

## 변경 사항

### `src/data_client/korean/fundamentals_source.py` (신규)
`KoreanFundamentalsSource` class:
- **quote**: `yfinance.Ticker(symbol).fast_info` — `marketCap` / `yearHigh-Low` / `dayHigh-Low` / `shares` / `previousClose`
- **performance**: `pykrx.stock.get_market_ohlcv` 로 영업일 lookback 종가 비교 (1D/5D/1M/3M/6M/1Y/YTD %)

### `src/server/app/market_data.py`
- `is_unsupported_market` → `is_unsupported_analyst_market` rename + scope 좁힘 (analyst 만 unsupported)
- `/overview` 의 KR 분기에서 `KoreanFundamentalsSource.get_overview` 호출. 기존 캐시 (5분 TTL) 그대로
- source 실패 시 graceful `unsupported` fallback 응답

## 기술적 판단
- **왜 yfinance fast_info?**: pykrx 의 `get_market_fundamental` / `get_market_cap` 이 KRX 사이트 응답 구조 변경으로 `KeyError: ['BPS', 'PER', 'PBR', ...]` 발생 (확인됨). yfinance fast_info 는 KR ticker 도 즉시 안정적 응답 (1.46경원 시가총액 등 검증 완료). 새 dependency 0
- **왜 PER/PBR 본 PR 에서 미채움?**: yf `Ticker.info` 는 느리고 (~3-5s) 가끔 ratelimit 막힘. DART 분기 보고서 기반이 더 안정적이라 Stage C 에 양보
- **왜 영구 unsupported 가 아니라 source 호출 전환?**: KR 사용자에게 즉시 가시적 가치 (시가총액 + performance) 가 큼. 분기 fundamentals 는 별도 PR 로 점진 채우기

## 검증
- `uv run pytest tests/unit/data_client/korean/test_fundamentals_source.py -v` → 13/13 통과 (mock 기반: yf/pykrx 외부 호출 monkeypatch)
- `uv run pytest tests/unit/data_client/ tests/unit/server/app/ -q` → 362/362 통과 (회귀 zero)
- `uv run ruff check src/data_client/korean/fundamentals_source.py src/server/app/market_data.py` → clean
- 수동 검증 권장: dev server 띄워 005930.KS 선택 → 차트 + 시가총액 + performance bar 표시

## 본 PR 미채움 (#42 Stage C 별도)
- quote: PER / PBR / EPS / 배당 (DART 권장)
- `analystRatings` (KR native source 없음 — 영구 unsupported 또는 DART 공시 sentiment)
- `quarterlyFundamentals` / `cashFlow` / `revenueByProduct/Geo` (DART 분기 사업보고서)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **새로운 기능**
  * 한국(.KS/.KQ) 종목 기본 정보(시세, 변동, 거래량, 시가총액 등) 및 1D/5D/1M/3M/6M/1Y/YTD 성과 지표 제공
  * 외부 데이터 부족 시 부분 결과(_partial) 반환으로 사용자 경험 개선

* **동작 변경**
  * KR 심볼에 대해 개요 호출이 전용 처리 및 캐시 적용(성공 300s, 부분/오류 60s)으로 응답 안정성 향상

* **테스트**
  * 한국용 단위/라우터 테스트 추가 및 보강
<!-- end of auto-generated comment: release notes by coderabbit.ai -->