### PR TITLE
feat: KR 분기 재무·현금흐름 DART finstate_all 통합 (#42)

### DIFF
--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -1,26 +1,28 @@
-"""KR fundamentals — quote enrichment + performance for KOSPI/KOSDAQ tickers.
+"""KR fundamentals — quote / performance / quarterly financials for KOSPI/KOSDAQ.
 
-FORK (#42 Stage A+B):
+FORK (#42):
 * Quote (시가총액 / 52W / dayHigh-Low / shares): yfinance ``fast_info`` 사용.
   pykrx 의 ``get_market_fundamental`` / ``get_market_cap`` 은 KRX 사이트 응답
   구조 변경으로 현재 KeyError 발생 — yfinance fast_info 가 KR ticker 도 안정적
   으로 처리.
 * Performance (1D / 5D / 1M / 3M / 6M / 1Y / YTD %): pykrx OHLCV 로 계산.
-  pykrx 의 일별 종가 endpoint 는 정상 동작.
-* PER / PBR / EPS / 배당: 본 source 에서는 미채움 (yf ``info`` 느려 timeout
-  위험. DART 분기 보고서 기반은 별도 issue).
-* analystRatings / quarterlyFundamentals / cashFlow / revenueByProduct/Geo:
-  별도 issue (DART 분기 사업보고서 파싱) 로 분리.
+* Quarterly fundamentals (revenue / operating income / net income) +
+  cashFlow (operating / investing / financing): DART finstate 누적 보고서
+  4개 (Q1 / H1 / 9M / FY) 를 가져와 차분으로 단일 분기 환산. ``DART_API_KEY``
+  미설정·요청 실패 시 None 으로 fallback — quote/performance 는 정상 응답.
+* PER / PBR / EPS / 배당 / analystRatings / revenueByProduct·Geo: 별도 issue.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import os
 from datetime import datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
+import pandas as pd
 import yfinance as yf
 from pykrx import stock
 
@@ -39,6 +41,41 @@ _PERIOD_BUSINESS_DAYS: dict[str, int] = {
     "1Y": 252,
 }
 
+# DART 보고서 코드 — Q1=11013, H1=11012(누적), 3Q=11014(누적), FY=11011(누적).
+# H1·9M·FY 는 누적치이므로 단일 분기 환산은 차분(subtraction) 필요.
+_DART_REPRT_CODES: list[tuple[str, str]] = [
+    ("Q1", "11013"),
+    ("H1", "11012"),
+    ("9M", "11014"),
+    ("FY", "11011"),
+]
+_DART_PREV_LABEL = {"H1": "Q1", "9M": "H1", "FY": "9M"}
+_DART_QUARTER_LABEL = {"Q1": "Q1", "H1": "Q2", "9M": "Q3", "FY": "Q4"}
+
+# 계정 매칭 — 우선 XBRL ``account_id`` (IFRS/DART 표준 ID, 회사간 안정) 으로
+# 매칭하고, 누락 시 ``account_nm`` substring 매칭으로 fallback (K-GAAP 등).
+# Tuple 안 순서 = 우선순위.
+_REVENUE_IDS = (
+    "ifrs-full_Revenue",
+    "ifrs-full_RevenueFromContractsWithCustomers",
+)
+_REVENUE_KEYWORDS = ("매출액", "수익(매출액)", "영업수익")
+
+_OPERATING_INCOME_IDS = ("dart_OperatingIncomeLoss",)
+_OPERATING_INCOME_KEYWORDS = ("영업이익",)
+
+_NET_INCOME_IDS = ("ifrs-full_ProfitLoss",)
+_NET_INCOME_KEYWORDS = ("당기순이익", "분기순이익", "반기순이익")
+
+_OPERATING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInOperatingActivities",)
+_OPERATING_CF_KEYWORDS = ("영업활동현금흐름", "영업활동으로 인한 현금흐름")
+
+_INVESTING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInInvestingActivities",)
+_INVESTING_CF_KEYWORDS = ("투자활동현금흐름", "투자활동으로 인한 현금흐름")
+
+_FINANCING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInFinancingActivities",)
+_FINANCING_CF_KEYWORDS = ("재무활동현금흐름", "재무활동으로 인한 현금흐름")
+
 
 def _strip_suffix(symbol: str) -> str:
     upper = symbol.upper()
@@ -49,9 +86,17 @@ def _strip_suffix(symbol: str) -> str:
 
 
 def _safe_float(value: Any) -> float | None:
-    """Coerce to float, returning None for NaN / None / non-numeric."""
+    """Coerce to float. None for NaN / None / non-numeric.
+
+    DART finstate 의 ``thstrm_amount`` 는 천단위 콤마 string ("79,140,503,000,000")
+    이므로 strip 후 파싱.
+    """
     if value is None:
         return None
+    if isinstance(value, str):
+        value = value.replace(",", "").strip()
+        if not value or value == "-":
+            return None
     try:
         f = float(value)
     except (TypeError, ValueError):
@@ -145,11 +190,196 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
     return perf
 
 
-class KoreanFundamentalsSource:
-    """quote + performance for KR ticker (.KS / .KQ).
+# ---------------------------------------------------------------------------
+# DART 분기 재무제표 — quarterlyFundamentals + cashFlow
+# ---------------------------------------------------------------------------
 
-    분기 사업보고서 기반 quarterlyFundamentals / cashFlow / revenueByProduct/Geo
-    는 별도 source (DART 통합 — issue #42 Stage C) 로 분리.
+# OpenDartReader 인스턴스는 corp_code XML(~5MB) 을 첫 호출에 download → 메모리 캐시.
+# /overview latency 보호 위해 모듈 싱글톤 — DART_API_KEY 미설정 시 None 반환.
+_dart_singleton: Any | None = None
+_dart_init_attempted: bool = False
+
+
+def _get_dart_client() -> Any | None:
+    """Lazy singleton OpenDartReader. ``None`` if API key missing or import fails."""
+    global _dart_singleton, _dart_init_attempted
+    if _dart_init_attempted:
+        return _dart_singleton
+    _dart_init_attempted = True
+    api_key = os.getenv("DART_API_KEY")
+    if not api_key:
+        logger.info("kr_fundamentals.dart.no_api_key")
+        return None
+    try:
+        import OpenDartReader  # noqa: N813 — package name is camelCase
+        _dart_singleton = OpenDartReader(api_key)
+    except Exception:
+        logger.warning("kr_fundamentals.dart.client_init.failed", exc_info=True)
+        _dart_singleton = None
+    return _dart_singleton
+
+
+def _row_cumulative_amount(row: pd.Series) -> float | None:
+    """누적치 추출 — DART finstate_all 의 sj_div 별 컬럼 의미 차이 정규화.
+
+    * IS (분기보고서) : ``thstrm_amount`` = 해당 분기 단독 (3M),
+      ``thstrm_add_amount`` = 연초부터 누적. → add_amount 우선.
+    * IS (사업보고서/Q1) : ``thstrm_add_amount`` 빈 값 → amount 가 곧 누적.
+    * CF / BS : ``thstrm_add_amount`` 가 NaN → amount 사용.
+
+    이 정규화로 모든 row 가 "연초부터 누적" 의미를 갖게 되어 차분 logic 단순화.
+    """
+    add_val = _safe_float(row.get("thstrm_add_amount"))
+    if add_val is not None and add_val != 0:
+        return add_val
+    return _safe_float(row.get("thstrm_amount"))
+
+
+def _extract_dart_amount(
+    df: pd.DataFrame,
+    account_ids: tuple[str, ...] = (),
+    account_keywords: tuple[str, ...] = (),
+    sj_divs: tuple[str, ...] = ("IS", "CIS", "CF"),
+) -> float | None:
+    """DART finstate_all DataFrame 에서 첫 매칭 row 의 누적금액 반환.
+
+    매칭 우선순위:
+    1. ``account_id`` exact match (IFRS / DART 표준 ID — 회사간 안정)
+    2. ``account_nm`` substring match (XBRL ID 없는 K-GAAP 회사 fallback)
+
+    값 추출은 ``_row_cumulative_amount`` — IS / CF schema 차이 정규화.
+    schema 변경 / 누락 column 모두 None 으로 안전 처리 — 직접 인덱싱은
+    KeyError 로 /overview 전체 500 으로 번질 수 있음.
+    """
+    if df is None or not isinstance(df, pd.DataFrame) or df.empty:
+        return None
+    if "thstrm_amount" not in df.columns:
+        return None
+
+    candidates = df[df["sj_div"].isin(sj_divs)] if "sj_div" in df.columns else df
+    # finstate (legacy) 는 fs_div column 으로 CFS/OFS 혼재 — CFS 우선.
+    # finstate_all 은 한 호출당 한 fs_div 라 column 자체가 없음.
+    if "fs_div" in candidates.columns:
+        cfs = candidates[candidates["fs_div"] == "CFS"]
+        if not cfs.empty:
+            candidates = cfs
+
+    if account_ids and "account_id" in candidates.columns:
+        for aid in account_ids:
+            matches = candidates[candidates["account_id"] == aid]
+            if not matches.empty:
+                return _row_cumulative_amount(matches.iloc[0])
+
+    if account_keywords and "account_nm" in candidates.columns:
+        for kw in account_keywords:
+            for _, row in candidates.iterrows():
+                if kw in str(row.get("account_nm", "")):
+                    return _row_cumulative_amount(row)
+    return None
+
+
+def _fetch_dart_quarterlies(
+    stock_code: str,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """DART 분기 재무로 (quarterlyFundamentals, cashFlow) 도출. 최근 4개 분기.
+
+    DART 의 H1/9M/FY thstrm_amount 는 누적치 — 직전 누적 빼서 단일 분기 환산.
+    직전 보고서가 없으면 (예: H1 만 공시되고 Q1 누락) 해당 분기 skip.
+
+    Returns
+    -------
+    fundamentals : list[{period, revenue, operatingIncome, netIncome}]
+    cashflow : list[{period, operatingCashFlow, investingCashFlow, financingCashFlow}]
+
+    DART 미설정 / 모든 보고서 fetch 실패 시 ``([], [])``.
+    """
+    dart = _get_dart_client()
+    if dart is None:
+        return [], []
+
+    today = datetime.now(_KST)
+    years = (today.year - 1, today.year)
+
+    cumulative: dict[tuple[int, str], dict[str, float | None]] = {}
+    for year in years:
+        for label, reprt_code in _DART_REPRT_CODES:
+            try:
+                # finstate (key items) 는 CF rows 가 없어서 cashFlow 채울 수 없음.
+                # finstate_all 은 XBRL 전체 항목 + account_id 까지 포함 — IFRS 표준 ID
+                # 매칭으로 회사간 robust. 기본 fs_div='CFS' (연결재무제표).
+                df = dart.finstate_all(stock_code, year, reprt_code=reprt_code)
+            except Exception:
+                logger.warning(
+                    "kr_fundamentals.dart.finstate_all.failed | corp=%s year=%s reprt=%s",
+                    stock_code, year, reprt_code, exc_info=True,
+                )
+                continue
+            if df is None or not isinstance(df, pd.DataFrame) or df.empty:
+                continue
+            cumulative[(year, label)] = {
+                "revenue": _extract_dart_amount(df, _REVENUE_IDS, _REVENUE_KEYWORDS, sj_divs=("IS", "CIS")),
+                "operatingIncome": _extract_dart_amount(df, _OPERATING_INCOME_IDS, _OPERATING_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
+                "netIncome": _extract_dart_amount(df, _NET_INCOME_IDS, _NET_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
+                "operatingCashFlow": _extract_dart_amount(df, _OPERATING_CF_IDS, _OPERATING_CF_KEYWORDS, sj_divs=("CF",)),
+                "investingCashFlow": _extract_dart_amount(df, _INVESTING_CF_IDS, _INVESTING_CF_KEYWORDS, sj_divs=("CF",)),
+                "financingCashFlow": _extract_dart_amount(df, _FINANCING_CF_IDS, _FINANCING_CF_KEYWORDS, sj_divs=("CF",)),
+            }
+
+    if not cumulative:
+        return [], []
+
+    quarters: list[dict[str, Any]] = []
+    period_sequence = [(y, lbl) for y in sorted(years) for lbl, _ in _DART_REPRT_CODES]
+    for year, label in period_sequence:
+        cum = cumulative.get((year, label))
+        if cum is None:
+            continue
+        if label == "Q1":
+            single = dict(cum)
+        else:
+            prev = cumulative.get((year, _DART_PREV_LABEL[label]))
+            if prev is None:
+                continue
+            single = {
+                k: (cum[k] - prev[k]) if (cum[k] is not None and prev[k] is not None) else None
+                for k in cum
+            }
+        period = f"{year} {_DART_QUARTER_LABEL[label]}"
+        quarters.append({"period": period, **single})
+
+    quarters = quarters[-4:]
+
+    fundamentals = [
+        {
+            "period": q["period"],
+            "revenue": q["revenue"],
+            "operatingIncome": q["operatingIncome"],
+            "netIncome": q["netIncome"],
+        }
+        for q in quarters
+    ]
+    cashflow = [
+        {
+            "period": q["period"],
+            "operatingCashFlow": q["operatingCashFlow"],
+            "investingCashFlow": q["investingCashFlow"],
+            "financingCashFlow": q["financingCashFlow"],
+        }
+        for q in quarters
+    ]
+    return fundamentals, cashflow
+
+
+# ---------------------------------------------------------------------------
+# Source class
+# ---------------------------------------------------------------------------
+
+
+class KoreanFundamentalsSource:
+    """quote + performance + quarterly fundamentals/cashFlow for KR ticker (.KS / .KQ).
+
+    revenueByProduct / revenueByGeo / earningsSurprises / analyst consensus 는
+    별도 source — XBRL 본문 파싱 (segment) / 별도 컨센서스 데이터 필요.
     """
 
     @staticmethod
@@ -160,7 +390,9 @@ class KoreanFundamentalsSource:
     async def get_overview(self, symbol: str) -> dict[str, Any]:
         """Return CompanyOverviewResponse 호환 dict (KR 채울 수 있는 부분만).
 
-        외부 호출 (yfinance + pykrx) 은 ``asyncio.to_thread`` 로 wrap.
+        외부 호출 (yfinance + pykrx + DART) 은 ``asyncio.to_thread`` 로 wrap +
+        ``asyncio.gather`` 로 병렬. DART 미설정·실패는 fundamentals/cashFlow
+        만 None 으로 graceful degrade — quote/performance 응답은 정상.
         """
         # FORK (#42): supports() / is_unsupported_analyst_market 와 동일하게 strip 먼저.
         # 호출자가 이미 normalize 했더라도 source 자체가 raw input 안전 처리.
@@ -168,10 +400,12 @@ class KoreanFundamentalsSource:
         ticker = _strip_suffix(symbol)
         symbol_upper = symbol.upper()
 
-        quote, performance = await asyncio.gather(
+        quote, performance, dart_data = await asyncio.gather(
             asyncio.to_thread(_fetch_quote_from_yf, symbol_upper),
             asyncio.to_thread(_fetch_performance_from_pykrx, ticker),
+            asyncio.to_thread(_fetch_dart_quarterlies, ticker),
         )
+        fundamentals, cashflow = dart_data
 
         # quote 가 비었으면 unsupported 와 동일 — caller 가 unsupported flag 다시 세움.
         if not quote:
@@ -183,17 +417,17 @@ class KoreanFundamentalsSource:
                 "_partial": True,
             }
 
-        # name 은 yfinance fast_info 에 없음. Ticker.info 는 비싸서 생략 — 별도 PR.
+        # name 은 yfinance fast_info 에 없음. Ticker.info 는 비싸서 생략.
         return {
             "symbol": symbol_upper,
             "name": None,
             "quote": quote,
             "performance": performance,
-            # 본 PR 에서 채우지 않음 — DART 통합 별도 PR.
+            "quarterlyFundamentals": fundamentals or None,
+            "cashFlow": cashflow or None,
+            # 별도 issue — KR 컨센서스 source / XBRL segment 파싱 필요.
             "analystRatings": None,
-            "quarterlyFundamentals": None,
             "earningsSurprises": None,
-            "cashFlow": None,
             "revenueByProduct": None,
             "revenueByGeo": None,
         }

--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -18,6 +18,7 @@ from __future__ import annotations
 import asyncio
 import logging
 import os
+import threading
 from datetime import datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
@@ -196,8 +197,12 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
 
 # OpenDartReader 인스턴스는 corp_code XML(~5MB) 을 첫 호출에 download → 메모리 캐시.
 # /overview latency 보호 위해 모듈 싱글톤 — DART_API_KEY 미설정 시 None 반환.
+# Lock + double-checked init: 동시 /overview 요청이 to_thread 에서 동시에 들어오면
+# init 중인 thread 외 다른 thread 가 init_attempted=True 만 보고 미완성 None 받는
+# race 방지 — 첫 thread 가 OpenDartReader instantiate (수초 소요) 끝낼 때까지 wait.
 _dart_singleton: Any | None = None
 _dart_init_attempted: bool = False
+_dart_init_lock = threading.Lock()
 
 
 def _get_dart_client() -> Any | None:
@@ -205,17 +210,23 @@ def _get_dart_client() -> Any | None:
     global _dart_singleton, _dart_init_attempted
     if _dart_init_attempted:
         return _dart_singleton
-    _dart_init_attempted = True
-    api_key = os.getenv("DART_API_KEY")
-    if not api_key:
-        logger.info("kr_fundamentals.dart.no_api_key")
-        return None
-    try:
-        import OpenDartReader  # noqa: N813 — package name is camelCase
-        _dart_singleton = OpenDartReader(api_key)
-    except Exception:
-        logger.warning("kr_fundamentals.dart.client_init.failed", exc_info=True)
-        _dart_singleton = None
+    with _dart_init_lock:
+        # double-check: 다른 thread 가 lock 안에서 이미 init 끝냈을 수 있음.
+        if _dart_init_attempted:
+            return _dart_singleton
+        api_key = os.getenv("DART_API_KEY")
+        if not api_key:
+            logger.info("kr_fundamentals.dart.no_api_key")
+            _dart_singleton = None
+        else:
+            try:
+                import OpenDartReader  # noqa: N813 — package name is camelCase
+                _dart_singleton = OpenDartReader(api_key)
+            except Exception:
+                logger.warning("kr_fundamentals.dart.client_init.failed", exc_info=True)
+                _dart_singleton = None
+        # init 완전히 끝난 후 flag — 미완성 상태 노출 안 됨.
+        _dart_init_attempted = True
     return _dart_singleton
 
 
@@ -229,8 +240,11 @@ def _row_cumulative_amount(row: pd.Series) -> float | None:
 
     이 정규화로 모든 row 가 "연초부터 누적" 의미를 갖게 되어 차분 logic 단순화.
     """
+    # add_amount = 0 도 valid (해당 분기 누적이 정확히 0 인 항목 — 드물지만 가능).
+    # `_safe_float` 가 None / NaN / 빈 문자열을 None 으로 정규화하므로
+    # is-not-None 만으로 missing 판정 충분.
     add_val = _safe_float(row.get("thstrm_add_amount"))
-    if add_val is not None and add_val != 0:
+    if add_val is not None:
         return add_val
     return _safe_float(row.get("thstrm_amount"))
 
@@ -298,7 +312,9 @@ def _fetch_dart_quarterlies(
         return [], []
 
     today = datetime.now(_KST)
-    years = (today.year - 1, today.year)
+    # 직전 2년 + 당해 — 연초 (예: 1~3월) 에는 직전 해 FY 미공시라 (마감 90일 전)
+    # 직전-1 의 Q4 까지 거슬러 올라가야 quarters[-4:] 가 4개 채워짐.
+    years = (today.year - 2, today.year - 1, today.year)
 
     cumulative: dict[tuple[int, str], dict[str, float | None]] = {}
     for year in years:

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -8,6 +8,7 @@ helper 로 분리해뒀으니 monkeypatch 로 deterministic mock. integration �
 
 from __future__ import annotations
 
+from typing import Any
 from unittest.mock import MagicMock
 
 import pandas as pd
@@ -334,6 +335,126 @@ class TestExtractDartAmount:
             "thstrm_add_amount": float("nan"),
         }])
         assert fs._extract_dart_amount(df_cf, fs._OPERATING_CF_IDS, fs._OPERATING_CF_KEYWORDS, sj_divs=("CF",)) == 33_941_002_000_000.0
+
+    def test_treats_zero_thstrm_add_amount_as_valid(self):
+        """add_amount = 0 도 valid 누적치 — amount 로 fallback 하면 안 됨.
+
+        회귀 방지 — 이전엔 ``add_val != 0`` guard 로 정확히 0 인 cumulative 가
+        falsey 로 취급돼 thstrm_amount (단일 분기) 로 fallback. 차분 logic 이
+        틀어져 다음 분기 계산 결과까지 오염됨.
+        """
+        df = _make_dart_df([{
+            "sj_div": "CF",
+            "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities",
+            "account_nm": "투자활동현금흐름",
+            "thstrm_amount": "999",      # 만약 fallback 되면 이 값 반환
+            "thstrm_add_amount": "0",    # cumulative = 0 (정확히 0 인 분기)
+        }])
+        result = fs._extract_dart_amount(df, fs._INVESTING_CF_IDS, fs._INVESTING_CF_KEYWORDS, sj_divs=("CF",))
+        assert result == 0.0
+
+
+def test_fetch_dart_quarterlies_recovers_n_minus_2_q4_when_prior_year_fy_missing(monkeypatch):
+    """연초 (FY 미공시) 시나리오 — 직전-1 Q4 까지 거슬러 quarters[-4:] 4개 확보.
+
+    회귀 방지 — years 가 (N-1, N) 만 fetch 하면 1~3월 (FY 마감 90일 전) 에는
+    직전 해 FY 누락으로 Q4 못 만들고, 결과적으로 quarters 가 3개 (Q1/Q2/Q3) 만
+    돼서 frontend 분기 차트가 비어있는 분기 칸으로 보임.
+    """
+    # 시나리오: today = 2026-02-01 (이른 연초). 2025 FY 아직 미공시.
+    # 2025 Q1/H1/9M 만 공시, 2024 는 모두 공시 완료.
+    full_year = lambda mult=1: _build_finstate_df(  # noqa: E731
+        100 * mult, 10 * mult, 8 * mult, 20 * mult, -15 * mult, -3 * mult,
+    )
+    h1 = lambda mult=1: _build_finstate_df(  # noqa: E731
+        250 * mult, 28 * mult, 22 * mult, 50 * mult, -38 * mult, -8 * mult,
+    )
+    nine_m = lambda mult=1: _build_finstate_df(  # noqa: E731
+        400 * mult, 48 * mult, 38 * mult, 80 * mult, -60 * mult, -13 * mult,
+    )
+    fy = lambda mult=1: _build_finstate_df(  # noqa: E731
+        600 * mult, 75 * mult, 60 * mult, 120 * mult, -90 * mult, -20 * mult,
+    )
+
+    def finstate_all(corp, year, reprt_code):
+        # 2024: 전부 공시
+        if year == 2024:
+            return {"11013": full_year(1), "11012": h1(1), "11014": nine_m(1), "11011": fy(1)}.get(reprt_code)
+        # 2025: Q1/H1/9M 만 공시 (FY 아직 안 나옴)
+        if year == 2025:
+            return {"11013": full_year(2), "11012": h1(2), "11014": nine_m(2)}.get(reprt_code)
+        return None
+
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = finstate_all
+    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
+
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2026, 2, 1, tzinfo=tz)
+    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+
+    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
+
+    # quarters[-4:] = 2024 Q4 + 2025 Q1/Q2/Q3 — 4개 확보
+    periods = [q["period"] for q in fundamentals]
+    assert periods == ["2024 Q4", "2025 Q1", "2025 Q2", "2025 Q3"]
+    # 2024 Q4 = FY - 9M = (600 - 400) = 200
+    assert fundamentals[0]["revenue"] == 200.0
+    # 2025 Q1 = mult 2 → 200
+    assert fundamentals[1]["revenue"] == 200.0
+
+
+def test_get_dart_client_lock_prevents_concurrent_init_returning_none(monkeypatch):
+    """동시 호출 시 init 중인 thread 외 다른 thread 가 미완성 None 받지 않음.
+
+    회귀 방지 — 이전엔 init_attempted 를 OpenDartReader instantiate 전에 set 했고,
+    instantiate 가 수초 걸리는 동안 다른 thread 들이 None 을 받아 fundamentals
+    데이터 누락. Lock + flag-after-init 로 모든 thread 가 같은 결과 봄.
+    """
+    import threading as _threading
+    monkeypatch.setenv("DART_API_KEY", "fake-key")
+    init_call_count = 0
+    init_started = _threading.Event()
+    init_can_finish = _threading.Event()
+
+    class SlowOpenDartReader:
+        def __init__(self, key):
+            nonlocal init_call_count
+            init_call_count += 1
+            init_started.set()
+            init_can_finish.wait(timeout=2)
+
+    import sys
+    fake_module = type(sys)("OpenDartReader")
+    fake_module.__call__ = SlowOpenDartReader
+    # OpenDartReader 는 모듈명도 클래스명도 OpenDartReader — `import OpenDartReader; OpenDartReader(key)`
+    # 패턴이라 모듈을 callable 로 만들기 보다 sys.modules 통째로 mock.
+    sys.modules["OpenDartReader"] = SlowOpenDartReader  # type: ignore[assignment]
+
+    results: list[Any] = []
+
+    def call_get_client():
+        results.append(fs._get_dart_client())
+
+    t1 = _threading.Thread(target=call_get_client)
+    t2 = _threading.Thread(target=call_get_client)
+    t1.start()
+    init_started.wait(timeout=2)  # t1 이 instantiate 진입할 때까지 대기
+    t2.start()  # t2 는 lock 에서 wait 해야 함
+    init_can_finish.set()
+    t1.join(timeout=3)
+    t2.join(timeout=3)
+
+    # init 은 정확히 1번만, 두 thread 모두 같은 instance 받음 (None 없음).
+    assert init_call_count == 1
+    assert all(r is not None for r in results), f"got None during concurrent init: {results}"
+    assert results[0] is results[1]
+
+    # cleanup: sys.modules 복원
+    del sys.modules["OpenDartReader"]
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -1,17 +1,26 @@
 """
-Tests for KoreanFundamentalsSource (issue #42 Stage A+B).
+Tests for KoreanFundamentalsSource (issue #42).
 
-External calls (yfinance fast_info, pykrx OHLCV) 은 module-level helper 로
-분리해뒀으니 monkeypatch 로 deterministic mock. integration 검증 (실제 yf/pykrx
-hit) 은 별도 (외부 의존이라 unit suite 에 포함 안 함).
+External calls (yfinance fast_info, pykrx OHLCV, DART finstate) 은 module-level
+helper 로 분리해뒀으니 monkeypatch 로 deterministic mock. integration 검증
+(실제 yf/pykrx/DART hit) 은 별도 — 외부 의존이라 unit suite 에 포함 안 함.
 """
 
 from __future__ import annotations
+
+from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
 
 from src.data_client.korean import fundamentals_source as fs
+
+
+@pytest.fixture(autouse=True)
+def _reset_dart_singleton(monkeypatch):
+    """DART 모듈 싱글톤은 테스트 격리 — 매 테스트 fresh state 로 시작."""
+    monkeypatch.setattr(fs, "_dart_singleton", None)
+    monkeypatch.setattr(fs, "_dart_init_attempted", False)
 
 
 # ---------------------------------------------------------------------------
@@ -58,6 +67,8 @@ async def test_get_overview_returns_quote_and_performance(monkeypatch):
 
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: fake_quote)
     monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: fake_perf)
+    # DART 미설정 시나리오 — fundamentals/cashFlow 빈 응답
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: ([], []))
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("005930.KS")
@@ -65,9 +76,10 @@ async def test_get_overview_returns_quote_and_performance(monkeypatch):
     assert result["symbol"] == "005930.KS"
     assert result["quote"] == fake_quote
     assert result["performance"] == fake_perf
-    # 본 stage 에서 채우지 않는 필드는 None — frontend 가 빈 카드 안전 렌더
+    # 본 PR 에서 채우지 않는 필드는 None — frontend 가 빈 카드 안전 렌더
     assert result["analystRatings"] is None
     assert result["quarterlyFundamentals"] is None
+    assert result["cashFlow"] is None
 
 
 @pytest.mark.asyncio
@@ -83,8 +95,13 @@ async def test_get_overview_strips_whitespace_from_symbol(monkeypatch):
         captured["pykrx_ticker"] = ticker
         return {"1D": 0.0}
 
+    def capture_dart(corp: str) -> tuple[list, list]:
+        captured["dart_corp"] = corp
+        return ([], [])
+
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", capture_quote)
     monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", capture_perf)
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", capture_dart)
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("  005930.KS  ")
@@ -92,6 +109,7 @@ async def test_get_overview_strips_whitespace_from_symbol(monkeypatch):
     # symbol/ticker 모두 strip 됐는지 — 공백이 외부 호출까지 leak 안 돼야
     assert captured["yf_symbol"] == "005930.KS"
     assert captured["pykrx_ticker"] == "005930"
+    assert captured["dart_corp"] == "005930"
     assert result["symbol"] == "005930.KS"
 
 
@@ -102,6 +120,7 @@ async def test_get_overview_yf_fail_returns_partial(monkeypatch):
     monkeypatch.setattr(
         fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 1.0}
     )
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: ([], []))
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("005930.KS")
@@ -109,6 +128,28 @@ async def test_get_overview_yf_fail_returns_partial(monkeypatch):
     assert result["_partial"] is True
     assert result["quote"] is None
     assert result["performance"] is None
+
+
+@pytest.mark.asyncio
+async def test_get_overview_includes_dart_quarterly_data(monkeypatch):
+    """DART 정상 응답 시 quarterlyFundamentals + cashFlow 가 overview 에 포함."""
+    fundamentals = [
+        {"period": "2025 Q3", "revenue": 80_000_000_000_000.0, "operatingIncome": 9_000_000_000_000.0, "netIncome": 7_000_000_000_000.0},
+        {"period": "2025 Q4", "revenue": 85_000_000_000_000.0, "operatingIncome": 10_500_000_000_000.0, "netIncome": 8_000_000_000_000.0},
+    ]
+    cashflow = [
+        {"period": "2025 Q3", "operatingCashFlow": 12_000_000_000_000.0, "investingCashFlow": -8_000_000_000_000.0, "financingCashFlow": -3_000_000_000_000.0},
+        {"period": "2025 Q4", "operatingCashFlow": 14_000_000_000_000.0, "investingCashFlow": -9_500_000_000_000.0, "financingCashFlow": -3_500_000_000_000.0},
+    ]
+    monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: {"price": 75000.0})
+    monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 0.5})
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: (fundamentals, cashflow))
+
+    source = fs.KoreanFundamentalsSource()
+    result = await source.get_overview("005930.KS")
+
+    assert result["quarterlyFundamentals"] == fundamentals
+    assert result["cashFlow"] == cashflow
 
 
 # ---------------------------------------------------------------------------
@@ -189,3 +230,255 @@ class TestSafeFloat:
     def test_non_numeric_returns_none(self):
         assert fs._safe_float("abc") is None
         assert fs._safe_float({}) is None
+
+
+# ---------------------------------------------------------------------------
+# _extract_dart_amount — DART finstate row 매칭
+# ---------------------------------------------------------------------------
+
+
+def _make_dart_df(rows: list[dict]) -> pd.DataFrame:
+    """DART finstate-shape DataFrame helper."""
+    return pd.DataFrame(rows)
+
+
+class TestExtractDartAmount:
+    def test_account_id_match_takes_priority(self):
+        # account_id 와 account_nm 둘 다 있을 때 account_id 매칭 우선.
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": "200"},
+            {"sj_div": "IS", "account_id": "dart_OtherSales", "account_nm": "기타매출", "thstrm_amount": "999"},
+        ])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 200.0
+
+    def test_falls_back_to_account_nm_when_no_id_match(self):
+        # account_id 매칭 실패 → account_nm substring 으로 fallback (K-GAAP 회사 등).
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "custom_kgaap_revenue", "account_nm": "매출액", "thstrm_amount": "150"},
+        ])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 150.0
+
+    def test_substring_match_alternate_revenue_label(self):
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "x", "account_nm": "영업수익", "thstrm_amount": "300"},
+        ])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 300.0
+
+    def test_returns_none_when_no_match(self):
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "x", "account_nm": "기타수익", "thstrm_amount": "50"},
+        ])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
+
+    def test_filters_by_sj_div(self):
+        # CF 에서 영업이익 키워드 — IS 에만 한정하면 None
+        df = _make_dart_df([
+            {"sj_div": "CF", "account_id": "x", "account_nm": "영업이익", "thstrm_amount": "999"},
+        ])
+        assert fs._extract_dart_amount(df, (), fs._OPERATING_INCOME_KEYWORDS, sj_divs=("IS",)) is None
+        assert fs._extract_dart_amount(df, (), fs._OPERATING_INCOME_KEYWORDS, sj_divs=("CF",)) == 999.0
+
+    def test_handles_comma_formatted_amounts(self):
+        # finstate (legacy) 는 thstrm_amount 가 천단위 콤마 string
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": "79,140,503,000,000"},
+        ])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 79_140_503_000_000.0
+
+    def test_handles_missing_columns_safely(self):
+        # account_nm / account_id column 누락 — KeyError 대신 None
+        df = pd.DataFrame({"sj_div": ["IS"], "thstrm_amount": ["100"]})
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
+
+    def test_handles_empty_dataframe(self):
+        assert fs._extract_dart_amount(pd.DataFrame(), fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
+        assert fs._extract_dart_amount(None, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
+
+    def test_handles_dict_response_from_dart_no_data(self):
+        # OpenDartReader 가 'no data' 시 dict 반환하는 케이스 — DataFrame 아님 → None
+        no_data = {"status": "013", "message": "조회된 데이타가 없습니다."}
+        assert fs._extract_dart_amount(no_data, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
+
+    def test_prefers_thstrm_add_amount_for_is_rows(self):
+        """IS rows: thstrm_amount 는 단일 분기 (3M), thstrm_add_amount 는 연초 누적.
+
+        회귀 방지 — H1 보고서의 thstrm_amount (74,566억) 를 잘못 누적치로 쓰면
+        Q2 = H1 - Q1 = 음수가 나옴. 누적치 (thstrm_add_amount=153,706억) 우선.
+        """
+        df = _make_dart_df([{
+            "sj_div": "IS",
+            "account_id": "ifrs-full_Revenue",
+            "account_nm": "매출액",
+            "thstrm_amount": "74,566,317,000,000",
+            "thstrm_add_amount": "153,706,820,000,000",
+        }])
+        # add_amount = H1 cumulative — 누적치 우선
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 153_706_820_000_000.0
+
+    def test_falls_back_to_thstrm_amount_when_add_empty(self):
+        """FY 보고서 / Q1 보고서 / CF rows: thstrm_add_amount 비어있음 → amount 가 누적."""
+        df = _make_dart_df([{
+            "sj_div": "IS",
+            "account_id": "ifrs-full_Revenue",
+            "account_nm": "매출액",
+            "thstrm_amount": "333,605,938,000,000",
+            "thstrm_add_amount": "",  # FY report — add 비어있음
+        }])
+        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 333_605_938_000_000.0
+
+        df_cf = _make_dart_df([{
+            "sj_div": "CF",
+            "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities",
+            "account_nm": "영업활동현금흐름",
+            "thstrm_amount": "33,941,002,000,000",
+            "thstrm_add_amount": float("nan"),
+        }])
+        assert fs._extract_dart_amount(df_cf, fs._OPERATING_CF_IDS, fs._OPERATING_CF_KEYWORDS, sj_divs=("CF",)) == 33_941_002_000_000.0
+
+
+# ---------------------------------------------------------------------------
+# _fetch_dart_quarterlies — 누적 → 분기 차분 + DART 가용성 분기
+# ---------------------------------------------------------------------------
+
+
+def _build_finstate_df(
+    revenue_cum: float, op_cum: float, net_cum: float,
+    op_cf_cum: float, inv_cf_cum: float, fin_cf_cum: float,
+) -> pd.DataFrame:
+    """누적 금액으로 채운 DART finstate_all-shape DataFrame.
+
+    finstate_all 은 한 호출당 단일 fs_div ("CFS" 또는 "OFS") — fs_div column 없음.
+    account_id (XBRL 표준 ID) 와 account_nm 둘 다 채워서 매칭 fallback 검증.
+    """
+    return _make_dart_df([
+        {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": str(revenue_cum)},
+        {"sj_div": "IS", "account_id": "dart_OperatingIncomeLoss", "account_nm": "영업이익", "thstrm_amount": str(op_cum)},
+        {"sj_div": "IS", "account_id": "ifrs-full_ProfitLoss", "account_nm": "분기순이익", "thstrm_amount": str(net_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities", "account_nm": "영업활동현금흐름", "thstrm_amount": str(op_cf_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities", "account_nm": "투자활동현금흐름", "thstrm_amount": str(inv_cf_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInFinancingActivities", "account_nm": "재무활동현금흐름", "thstrm_amount": str(fin_cf_cum)},
+    ])
+
+
+def test_fetch_dart_quarterlies_returns_empty_when_no_client(monkeypatch):
+    """DART_API_KEY 미설정 (client=None) 이면 ([], []) — overview 는 정상 응답 유지."""
+    monkeypatch.setattr(fs, "_get_dart_client", lambda: None)
+    fundamentals, cashflow = fs._fetch_dart_quarterlies("005930")
+    assert fundamentals == []
+    assert cashflow == []
+
+
+def test_fetch_dart_quarterlies_subtracts_cumulative_to_single_quarter(monkeypatch):
+    """H1/9M/FY 의 누적치를 직전 보고서 빼서 단일 분기 환산."""
+    # 한 해 (year=2025) full data — Q1=100, H1=250 → Q2=150, 9M=400 → Q3=150, FY=600 → Q4=200
+    cumulative_by_period = {
+        "11013": _build_finstate_df(100, 10, 8, 20, -15, -3),    # Q1
+        "11012": _build_finstate_df(250, 28, 22, 50, -38, -8),   # H1 cumul
+        "11014": _build_finstate_df(400, 48, 38, 80, -60, -13),  # 9M cumul
+        "11011": _build_finstate_df(600, 75, 60, 120, -90, -20), # FY cumul
+    }
+    fake_dart = MagicMock()
+    # year=2024 (전년) 은 None — 조회는 시도되지만 빈 응답
+    # year=2025 (당해) 만 응답.
+
+    def finstate(corp, year, reprt_code):
+        if year != 2025:
+            return None
+        return cumulative_by_period.get(reprt_code)
+
+    fake_dart.finstate_all = finstate
+    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
+    # _KST.now() 의 year 로 fetch 범위 결정 — 2025 가 포함되도록 stub
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2025, 12, 31, tzinfo=tz)
+    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+
+    fundamentals, cashflow = fs._fetch_dart_quarterlies("005930")
+
+    # 4 quarters expected
+    assert len(fundamentals) == 4
+    assert [q["period"] for q in fundamentals] == ["2025 Q1", "2025 Q2", "2025 Q3", "2025 Q4"]
+    # Q1 = cumulative
+    assert fundamentals[0]["revenue"] == 100.0
+    # Q2 = H1 - Q1 = 250 - 100 = 150
+    assert fundamentals[1]["revenue"] == 150.0
+    # Q3 = 9M - H1 = 400 - 250 = 150
+    assert fundamentals[2]["revenue"] == 150.0
+    # Q4 = FY - 9M = 600 - 400 = 200
+    assert fundamentals[3]["revenue"] == 200.0
+
+    # cashflow 도 동일 로직으로 차분
+    assert cashflow[0]["operatingCashFlow"] == 20.0
+    assert cashflow[1]["operatingCashFlow"] == 30.0  # 50 - 20
+
+
+def test_fetch_dart_quarterlies_skips_quarter_when_prev_cumulative_missing(monkeypatch):
+    """Q1 보고서 누락 시 Q2 (=H1-Q1) 계산 불가 → skip. Q3/Q4 는 정상."""
+    cumulative_by_period = {
+        # 11013 (Q1) 누락 — Q2 계산 불가
+        "11012": _build_finstate_df(250, 28, 22, 50, -38, -8),
+        "11014": _build_finstate_df(400, 48, 38, 80, -60, -13),
+        "11011": _build_finstate_df(600, 75, 60, 120, -90, -20),
+    }
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = lambda corp, year, reprt_code: (
+        cumulative_by_period.get(reprt_code) if year == 2025 else None
+    )
+    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
+
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2025, 12, 31, tzinfo=tz)
+    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+
+    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
+
+    # Q1 자체도 없고 Q2 도 prev 없어서 skip — Q3/Q4 만 (단, Q3 도 H1 가 prev — H1 있으니 가능)
+    periods = [q["period"] for q in fundamentals]
+    assert "2025 Q1" not in periods
+    assert "2025 Q2" not in periods
+    assert "2025 Q3" in periods
+    assert "2025 Q4" in periods
+
+
+def test_fetch_dart_quarterlies_handles_finstate_exception(monkeypatch):
+    """finstate 가 예외 raise 해도 다른 보고서 fetch 는 계속 — 일부 분기만 나옴."""
+    fake_dart = MagicMock()
+
+    def flaky_finstate(corp, year, reprt_code):
+        if reprt_code == "11013":
+            raise RuntimeError("DART rate limit")
+        if year == 2025 and reprt_code == "11012":
+            return _build_finstate_df(250, 28, 22, 50, -38, -8)
+        if year == 2025 and reprt_code == "11014":
+            return _build_finstate_df(400, 48, 38, 80, -60, -13)
+        return None
+
+    fake_dart.finstate_all = flaky_finstate
+    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
+
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2025, 12, 31, tzinfo=tz)
+    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+
+    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
+    # Q1 raise → cumulative 누락 → Q2 skip; 9M 은 H1 prev 있으니 Q3 만 나옴
+    periods = [q["period"] for q in fundamentals]
+    assert periods == ["2025 Q3"]
+
+
+def test_get_dart_client_returns_none_without_api_key(monkeypatch):
+    """DART_API_KEY 환경변수 없으면 client = None — 모듈 import 시 raise 되지 않음."""
+    monkeypatch.delenv("DART_API_KEY", raising=False)
+    # autouse fixture 가 singleton reset 해줌
+    assert fs._get_dart_client() is None
+    # 두 번째 호출도 None — init_attempted flag 동작
+    assert fs._get_dart_client() is None


### PR DESCRIPTION
## 요약
Closes #42

`/overview` KR 분기에서 quarterlyFundamentals (revenue·operatingIncome·netIncome) + cashFlow (operating·investing·financing) 를 DART 분기 보고서 기반으로 채움. US ticker 와 동일한 응답 shape 이라 frontend `QuarterlyRevenueChart` / `CashFlowChart` 가 그대로 렌더.

## 변경 사항
- `src/data_client/korean/fundamentals_source.py`
  - `_fetch_dart_quarterlies(stock_code)` 추가 — 직전 1년 + 당해 의 4개 보고서 fetch (Q1=11013, H1=11012, 9M=11014, FY=11011), 누적치를 차분해서 단일 분기 환산
  - `_extract_dart_amount(df, account_ids, account_keywords, sj_divs)` — XBRL `account_id` (IFRS/DART 표준) 우선 매칭, 없으면 `account_nm` substring fallback. CFS 우선
  - `_row_cumulative_amount(row)` — IS rows 의 `thstrm_amount` (단일 분기) vs `thstrm_add_amount` (연초 누적) 차이 정규화. CF rows 는 amount 가 누적
  - `_get_dart_client()` — OpenDartReader 모듈 싱글톤 + lazy init (corp_code XML 5MB download 비용 보호). `DART_API_KEY` 누락 시 None
  - `_safe_float` 가 천단위 콤마 포함 string ("79,140,503,000,000") 도 파싱
  - `KoreanFundamentalsSource.get_overview` 가 yf + pykrx + DART 3개를 `asyncio.gather` 로 병렬 호출 → fundamentals/cashFlow 채움. DART 실패 시 None 으로 graceful degrade (quote/performance 는 정상)
- `tests/unit/data_client/korean/test_fundamentals_source.py`
  - 18개 신규 테스트: `account_id` 우선 매칭 / keyword fallback / `thstrm_add_amount` 우선 / cumulative subtraction / 직전 보고서 누락 시 skip / `finstate_all` 예외 / DART client 미설정 시 빈 응답 / dict (no-data) 응답 처리 / 콤마 포함 string 파싱 / 회귀 방지 (Q2 = H1 - Q1 음수 버그)
  - autouse fixture 로 DART 싱글톤 reset — 테스트 격리

## 기술적 판단
- **`finstate` → `finstate_all` 전환**: `finstate` 는 key items 만 (BS+IS) 반환하고 CF rows 가 없어서 cashFlow 채울 수 없음. `finstate_all` 은 XBRL 전체 + `account_id` 까지 포함 — 회사간 안정적인 매칭 가능
- **account_id 우선 매칭**: `ifrs-full_Revenue` 같은 표준 ID 는 회사가 바뀌어도 동일. account_nm 은 회사마다 "매출액"/"영업수익"/"수익(매출액)" 등 다양. ID 매칭 실패 시 keyword substring 으로 fallback (K-GAAP 회사)
- **누적치 정규화**: DART finstate_all 의 IS rows 는 `thstrm_amount` 가 단일 분기 (3M), `thstrm_add_amount` 가 연초 누적. CF rows 는 `thstrm_amount` 가 누적, `add_amount` 는 NaN. `_row_cumulative_amount` 가 add_amount 우선·amount fallback 으로 통일 → 모든 row 가 "연초 누적" 의미가 되어 차분 logic 단순화. 첫 구현은 `thstrm_amount` 만 봐서 H1-Q1 = 음수가 나오는 버그 발견 → 회귀 방지 테스트 추가
- **PER/PBR/EPS·analystRatings·revenueByProduct/Geo 미포함**: 별도 source 필요 (KR 컨센서스 없음, segment 는 XBRL 본문 파싱 필요). 본 PR 은 DART finstate_all 만으로 채울 수 있는 범위에 한정

## 검증
- `pytest tests/unit/data_client/korean/ tests/unit/server/app/`: **384 passed**
- `ruff check`: 통과
- 005930.KS (삼성전자) 실제 DART 호출: 2025 Q1-Q4 매출 79·74.6·86·93.8조 / 영업이익 6.7·4.7·12.2·20.1조 — 공시 수치 일치
- `KoreanFundamentalsSource.get_overview('005930.KS')` 통합: quote.marketCap=1,459조 / performance.1Y=292% / quarterlyFundamentals 4개 / cashFlow 4개 모두 정상 반환

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# 릴리스 노트

* **새로운 기능**
  * DART 기반 분기 재무 데이터 추가로 더 상세한 재무 정보 제공
  * 매출, 영업이익, 순이익, 현금흐름 등 주요 재무 지표 포함
  * 여러 데이터 소스를 병렬로 처리하여 성능 향상

* **테스트**
  * DART 데이터 처리 및 분기 변환 로직에 대한 포괄적인 단위 테스트 추가

<!-- end of auto-generated comment: release notes by coderabbit.ai -->