### PR TITLE
fix(memo): PDF 추출 worker thread leak — ProcessPoolExecutor 전환

### DIFF
--- a/src/ptc_agent/agent/memo/pdf.py
+++ b/src/ptc_agent/agent/memo/pdf.py
@@ -4,13 +4,22 @@ Mirrors the internals of ``src/tools/crawler/extractors/pdf.py`` but takes
 ``bytes`` directly instead of a URL. The crawler's ``PdfExtractor`` downloads
 the PDF over HTTP — wrong entry point for memo uploads where the bytes are
 already in hand.
+
+Extraction runs in a subprocess (spawn context) so a hung ``pdfplumber`` or
+``pypdf`` call can be killed on timeout. The previous
+``asyncio.wait_for(asyncio.to_thread(...))`` pattern only cancelled the
+asyncio Future — the worker thread kept running with ~1 GB RSS, defeating the
+``_EXTRACTION_CONCURRENCY`` cap once the semaphore released.
 """
 
 from __future__ import annotations
 
 import asyncio
 import logging
+import multiprocessing as mp
+from collections.abc import Callable
 from io import BytesIO
+from multiprocessing.connection import Connection
 
 from ptc_agent.agent.memo.schema import (
     MEMO_CONTENT_MIN_CHARS,
@@ -35,6 +44,14 @@ _MAX_PDF_PAGES = 500
 # uploads land at once. Additional uploads queue on this semaphore.
 _EXTRACTION_CONCURRENCY = 2
 _EXTRACTION_SEM = asyncio.Semaphore(_EXTRACTION_CONCURRENCY)
+
+# Spawn (not fork): FastAPI runs threads (uvicorn loop, logging, asyncio I/O)
+# and fork+threads is unsafe — known to deadlock libssl, glibc allocator, etc.
+# Spawn pays ~100 ms to boot a fresh interpreter, negligible against the
+# multi-second extraction work.
+_MP_CTX = mp.get_context("spawn")
+# Grace window between SIGTERM and SIGKILL when killing a runaway subprocess.
+_PROC_KILL_GRACE_S = 1.0
 
 
 class MemoPdfExtractionError(Exception):
@@ -96,6 +113,102 @@ def _pypdf_extract(content: bytes) -> str:
     return "\n\n".join(pages)
 
 
+def _subprocess_entry(
+    extractor: Callable[[bytes], str],
+    content: bytes,
+    conn: Connection,
+) -> None:
+    """Run ``extractor`` in the subprocess and ship the result back via Pipe.
+
+    Catches ``BaseException`` so even ``MemoryError`` / ``KeyboardInterrupt``
+    propagate to the parent instead of leaving it blocked on ``poll()``.
+    """
+    try:
+        result = extractor(content)
+        conn.send(("ok", result))
+    except BaseException as exc:  # noqa: BLE001 — must round-trip every failure
+        try:
+            conn.send(("err", exc))
+        except Exception:
+            # Exception is not picklable — fall through; parent will see EOF
+            # when conn closes and raise a generic extractor failure.
+            pass
+    finally:
+        conn.close()
+
+
+def _terminate(proc: mp.Process) -> None:
+    """SIGTERM the worker, escalate to SIGKILL after the grace window."""
+    if not proc.is_alive():
+        return
+    proc.terminate()
+    proc.join(timeout=_PROC_KILL_GRACE_S)
+    if proc.is_alive():
+        proc.kill()
+        proc.join()
+
+
+def _run_in_subprocess_blocking(
+    extractor: Callable[[bytes], str],
+    content: bytes,
+    timeout: float,
+) -> str:
+    """Spawn ``extractor`` in a fresh subprocess and wait up to ``timeout``.
+
+    Returns the extractor's return value. On timeout, terminates the
+    subprocess (SIGTERM, then SIGKILL after the grace window) and raises
+    ``asyncio.TimeoutError``. Any exception raised inside the subprocess is
+    pickled across the Pipe and re-raised here.
+
+    Designed to be wrapped by ``asyncio.to_thread`` from the async layer —
+    the in-process timeout (``timeout + _PROC_KILL_GRACE_S`` upper bound)
+    means the wrapping thread always returns instead of leaking.
+    """
+    parent_conn, child_conn = _MP_CTX.Pipe(duplex=False)
+    proc = _MP_CTX.Process(
+        target=_subprocess_entry,
+        args=(extractor, content, child_conn),
+        daemon=True,
+    )
+    proc.start()
+    # Close the child end in the parent: ensures recv() raises EOFError
+    # promptly if the worker dies without sending anything (segfault, OOM
+    # kill) instead of blocking until the next send.
+    child_conn.close()
+    try:
+        if not parent_conn.poll(timeout):
+            _terminate(proc)
+            raise asyncio.TimeoutError(
+                f"PDF extraction timed out after {timeout}s"
+            )
+        try:
+            kind, payload = parent_conn.recv()
+        except EOFError as exc:
+            raise RuntimeError(
+                "PDF extractor subprocess died without sending a result"
+            ) from exc
+        proc.join()
+        if kind == "ok":
+            return payload
+        # Subprocess raised — re-raise the (pickled) exception in the parent.
+        raise payload
+    finally:
+        parent_conn.close()
+        _terminate(proc)
+
+
+async def _run_extractor(
+    extractor: Callable[[bytes], str], content: bytes
+) -> str:
+    """Async wrapper that runs the blocking subprocess runner off-loop."""
+    return await asyncio.to_thread(
+        _run_in_subprocess_blocking,
+        extractor,
+        content,
+        _EXTRACTION_TIMEOUT_S,
+    )
+
+
 async def extract_pdf_text(content: bytes) -> str:
     """Extract readable text from PDF bytes.
 
@@ -110,10 +223,7 @@ async def extract_pdf_text(content: bytes) -> str:
     async with _EXTRACTION_SEM:
         # Primary: pdfplumber
         try:
-            text = await asyncio.wait_for(
-                asyncio.to_thread(_pdfplumber_extract, content),
-                timeout=_EXTRACTION_TIMEOUT_S,
-            )
+            text = await _run_extractor(_pdfplumber_extract, content)
             if _is_usable(text):
                 return text
         except asyncio.TimeoutError:
@@ -132,10 +242,7 @@ async def extract_pdf_text(content: bytes) -> str:
 
         # Fallback: pypdf
         try:
-            text = await asyncio.wait_for(
-                asyncio.to_thread(_pypdf_extract, content),
-                timeout=_EXTRACTION_TIMEOUT_S,
-            )
+            text = await _run_extractor(_pypdf_extract, content)
             if _is_usable(text):
                 return text
         except asyncio.TimeoutError:

--- a/src/ptc_agent/agent/memo/pdf.py
+++ b/src/ptc_agent/agent/memo/pdf.py
@@ -165,17 +165,19 @@ def _run_in_subprocess_blocking(
     means the wrapping thread always returns instead of leaking.
     """
     parent_conn, child_conn = _MP_CTX.Pipe(duplex=False)
-    proc = _MP_CTX.Process(
-        target=_subprocess_entry,
-        args=(extractor, content, child_conn),
-        daemon=True,
-    )
-    proc.start()
-    # Close the child end in the parent: ensures recv() raises EOFError
-    # promptly if the worker dies without sending anything (segfault, OOM
-    # kill) instead of blocking until the next send.
-    child_conn.close()
+    proc: mp.Process | None = None
     try:
+        proc = _MP_CTX.Process(
+            target=_subprocess_entry,
+            args=(extractor, content, child_conn),
+            daemon=True,
+        )
+        proc.start()
+        # Close the child end in the parent: ensures recv() raises EOFError
+        # promptly if the worker dies without sending anything (segfault, OOM
+        # kill) instead of blocking until the next send.
+        child_conn.close()
+
         if not parent_conn.poll(timeout):
             _terminate(proc)
             raise asyncio.TimeoutError(
@@ -187,14 +189,26 @@ def _run_in_subprocess_blocking(
             raise RuntimeError(
                 "PDF extractor subprocess died without sending a result"
             ) from exc
-        proc.join()
+        # Bounded join: the worker has sent its result and should exit
+        # immediately, but its atexit/gc cleanup can occasionally drag.
+        # Don't pin the parent on it — the finally will _terminate() if it
+        # is still alive past the grace window.
+        proc.join(timeout=_PROC_KILL_GRACE_S)
         if kind == "ok":
             return payload
         # Subprocess raised — re-raise the (pickled) exception in the parent.
         raise payload
     finally:
         parent_conn.close()
-        _terminate(proc)
+        # Defensive: if proc.start() raised before our in-band close above ran,
+        # the child end would otherwise leak. Closing an already-closed
+        # Connection is a no-op.
+        try:
+            child_conn.close()
+        except Exception:
+            pass
+        if proc is not None:
+            _terminate(proc)
 
 
 async def _run_extractor(

--- a/tests/unit/ptc_agent/agent/memo/test_pdf.py
+++ b/tests/unit/ptc_agent/agent/memo/test_pdf.py
@@ -1,21 +1,42 @@
-"""Unit tests for PDF text extraction with pdfplumber/pypdf fallback."""
+"""Unit tests for PDF text extraction with pdfplumber/pypdf fallback.
+
+Extraction now runs in a subprocess (spawn) so a hung extractor can be
+killed on timeout. Tests at the control-flow level mock ``_run_extractor``
+and call the (mocked) extractor in-process — exercising the same async
+fall-through logic without paying spawn cost or pickling. The subprocess
+runner itself has its own end-to-end tests that spawn a real worker.
+"""
 
 from __future__ import annotations
 
+import asyncio
+import time
 from unittest.mock import patch
 
 import pytest
 
 from ptc_agent.agent.memo.pdf import (
     MemoPdfExtractionError,
+    MemoPdfTooManyPagesError,
+    _run_in_subprocess_blocking,
     extract_pdf_text,
 )
 
 
+async def _run_extractor_in_process(extractor, content):
+    """Stub that calls the (mocked) extractor in-process to bypass spawn."""
+    return extractor(content)
+
+
 class TestExtractPdfText:
+    """Control-flow tests: pdfplumber → pypdf fallback, error handling."""
+
     @pytest.mark.asyncio
     async def test_pdfplumber_success_returns_text(self):
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract",
             return_value="This is a PDF with plenty of readable content spanning multiple lines.",
         ) as mock_plumber, patch(
@@ -30,6 +51,9 @@ class TestExtractPdfText:
     async def test_pypdf_fallback_when_pdfplumber_returns_short(self):
         # pdfplumber returns < MEMO_CONTENT_MIN_CHARS (50) — should try pypdf.
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract", return_value="tiny"
         ), patch(
             "ptc_agent.agent.memo.pdf._pypdf_extract",
@@ -42,6 +66,9 @@ class TestExtractPdfText:
     @pytest.mark.asyncio
     async def test_pypdf_fallback_when_pdfplumber_raises(self):
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract",
             side_effect=RuntimeError("pdfplumber blew up"),
         ), patch(
@@ -55,6 +82,9 @@ class TestExtractPdfText:
     @pytest.mark.asyncio
     async def test_both_empty_raises_extraction_error(self):
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract", return_value=""
         ), patch(
             "ptc_agent.agent.memo.pdf._pypdf_extract", return_value=""
@@ -66,6 +96,9 @@ class TestExtractPdfText:
     @pytest.mark.asyncio
     async def test_both_below_minimum_raises(self):
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract", return_value="tiny"
         ), patch(
             "ptc_agent.agent.memo.pdf._pypdf_extract", return_value="also tiny"
@@ -76,6 +109,9 @@ class TestExtractPdfText:
     @pytest.mark.asyncio
     async def test_both_raise_raises_extraction_error(self):
         with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
             "ptc_agent.agent.memo.pdf._pdfplumber_extract",
             side_effect=RuntimeError("plumber"),
         ), patch(
@@ -84,3 +120,98 @@ class TestExtractPdfText:
         ):
             with pytest.raises(MemoPdfExtractionError):
                 await extract_pdf_text(b"%PDF-1.4 broken")
+
+    @pytest.mark.asyncio
+    async def test_pdfplumber_timeout_falls_back_to_pypdf(self):
+        async def timeout_then_succeed(extractor, content):
+            # Timeout on the first call (pdfplumber), succeed on the second
+            # (pypdf) by routing through the in-process stub.
+            from ptc_agent.agent.memo import pdf as pdf_module
+            if extractor is pdf_module._pdfplumber_extract:
+                raise asyncio.TimeoutError()
+            return extractor(content)
+
+        with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=timeout_then_succeed,
+        ), patch(
+            "ptc_agent.agent.memo.pdf._pypdf_extract",
+            return_value="x" * 100,
+        ) as mock_pypdf:
+            text = await extract_pdf_text(b"%PDF-1.4 slow")
+            assert text
+            mock_pypdf.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_too_many_pages_does_not_fall_back(self):
+        with patch(
+            "ptc_agent.agent.memo.pdf._run_extractor",
+            side_effect=_run_extractor_in_process,
+        ), patch(
+            "ptc_agent.agent.memo.pdf._pdfplumber_extract",
+            side_effect=MemoPdfTooManyPagesError("PDF has 1000 pages; max is 500."),
+        ), patch(
+            "ptc_agent.agent.memo.pdf._pypdf_extract"
+        ) as mock_pypdf:
+            with pytest.raises(MemoPdfTooManyPagesError):
+                await extract_pdf_text(b"%PDF-1.4 huge")
+            mock_pypdf.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Subprocess runner — real spawn tests
+#
+# These exercise ``_run_in_subprocess_blocking`` end-to-end: a real subprocess
+# is spawned, the extractor runs there, and the result (or exception) round-
+# trips through the Pipe. Each test caps at ~5 s; a regression to the old
+# in-thread pattern would either hang past the timeout (test fails on CI
+# runtime) or leak threads.
+# ---------------------------------------------------------------------------
+
+# Module-level helpers — must be importable by the spawn'd subprocess.
+
+def _ok_extractor(content: bytes) -> str:
+    return f"got {len(content)} bytes"
+
+
+def _failing_extractor(_content: bytes) -> str:
+    raise MemoPdfTooManyPagesError("synthetic page-cap trip")
+
+
+def _hanging_extractor(_content: bytes) -> str:
+    # Sleeps far longer than any realistic timeout — the test passes only if
+    # the parent kills the worker before this returns.
+    time.sleep(60)
+    return "should never get here"
+
+
+class TestSubprocessRunner:
+    def test_returns_extractor_result(self):
+        result = _run_in_subprocess_blocking(_ok_extractor, b"hello", timeout=10.0)
+        assert result == "got 5 bytes"
+
+    def test_propagates_subprocess_exception(self):
+        with pytest.raises(MemoPdfTooManyPagesError) as exc:
+            _run_in_subprocess_blocking(_failing_extractor, b"x", timeout=10.0)
+        assert "synthetic page-cap trip" in str(exc.value)
+
+    def test_timeout_kills_worker_within_grace(self):
+        """Hung extractor must be terminated, with parent returning promptly."""
+        start = time.monotonic()
+        with pytest.raises(asyncio.TimeoutError):
+            _run_in_subprocess_blocking(_hanging_extractor, b"x", timeout=0.5)
+        elapsed = time.monotonic() - start
+        # Upper bound: timeout (0.5) + grace (1.0) + spawn overhead (~0.5).
+        # Generous 5 s ceiling so CI scheduler hiccups don't false-fail; the
+        # regression we'd catch is "the call hangs past 30 s".
+        assert elapsed < 5.0, (
+            f"timeout cleanup took {elapsed:.2f}s — subprocess may not have been killed"
+        )
+
+    def test_back_to_back_calls_after_timeout(self):
+        """A timed-out call must not poison the subsequent call."""
+        with pytest.raises(asyncio.TimeoutError):
+            _run_in_subprocess_blocking(_hanging_extractor, b"x", timeout=0.3)
+        # Next call should succeed cleanly with a fresh subprocess.
+        result = _run_in_subprocess_blocking(_ok_extractor, b"hi", timeout=10.0)
+        assert result == "got 2 bytes"

--- a/tests/unit/ptc_agent/agent/memo/test_pdf.py
+++ b/tests/unit/ptc_agent/agent/memo/test_pdf.py
@@ -185,6 +185,16 @@ def _hanging_extractor(_content: bytes) -> str:
     return "should never get here"
 
 
+def _exiting_extractor(_content: bytes) -> str:
+    # ``os._exit`` bypasses Python cleanup — _subprocess_entry's finally never
+    # runs, so the child closes its Pipe end only via process death (the OS
+    # closing the fd). Exercises the EOF-from-dead-child path the parent
+    # surfaces as RuntimeError.
+    import os
+    os._exit(1)
+    return "unreachable"
+
+
 class TestSubprocessRunner:
     def test_returns_extractor_result(self):
         result = _run_in_subprocess_blocking(_ok_extractor, b"hello", timeout=10.0)
@@ -215,3 +225,10 @@ class TestSubprocessRunner:
         # Next call should succeed cleanly with a fresh subprocess.
         result = _run_in_subprocess_blocking(_ok_extractor, b"hi", timeout=10.0)
         assert result == "got 2 bytes"
+
+    def test_subprocess_dies_without_sending_raises_runtime_error(self):
+        """``os._exit`` skips _subprocess_entry's finally; parent sees EOF."""
+        with pytest.raises(RuntimeError) as exc:
+            _run_in_subprocess_blocking(_exiting_extractor, b"x", timeout=10.0)
+        msg = str(exc.value).lower()
+        assert "subprocess" in msg and "without sending" in msg


### PR DESCRIPTION
## 요약
Closes #50
`asyncio.wait_for(asyncio.to_thread(...))` 가 timeout 시 worker thread 를 못 죽이는 문제 — multiprocessing spawn + Pipe + SIGTERM/SIGKILL 패턴으로 교체.

## 변경 사항
- `src/ptc_agent/agent/memo/pdf.py`
  - `_subprocess_entry` / `_run_in_subprocess_blocking` / `_run_extractor` 추가 — per-call subprocess (spawn) + Pipe
  - timeout 시 SIGTERM → grace 1s → SIGKILL escalation
  - subprocess 내 예외는 pickle 되어 parent 에서 re-raise
- `tests/unit/ptc_agent/agent/memo/test_pdf.py`
  - 기존 control-flow 6개 + fallback 신규 2개: `_run_extractor` mock 으로 in-process stub routing
  - 신규 통합 4개 (실제 spawn): 정상 / 예외 pickle / timeout-kill / back-to-back

## 기술적 판단
- **spawn vs fork**: FastAPI 환경에서 fork+threads 는 libssl·glibc allocator deadlock 알려진 이슈. spawn 은 부팅 ~100ms 비용 있지만 multi-second 추출 작업에서는 무시 가능
- **per-call Process vs ProcessPoolExecutor pool**: pool 의 currently-running worker 를 stable API 로 죽일 방법이 없음 (`shutdown(cancel_futures=True)` 는 pending 만 cancel). per-call Process 는 코드 단순 + 정확한 kill 의미. 100ms × 2 (pdfplumber + pypdf fallback) = 200ms overhead 는 수용 가능
- **`_EXTRACTION_SEM` 유지**: spawn 부담 완충 + 기존 cap 의도 재확정. spawn timeout 으로 leak 은 사라졌지만 정상 동작 시에도 메모리 cap 유지

## 검증
- `uv run pytest tests/unit/ptc_agent/agent/memo/ tests/unit/server/app/test_memo_api.py` — 102 passed
- `uv run ruff check src/ptc_agent/agent/memo/pdf.py` — clean
- timeout-kill 테스트: 0.5s timeout 설정 → 5s 안에 정리 확인 (실측 1~2s)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * PDF 추출 기능의 안정성이 향상되었습니다. 작업이 응답하지 않는 상황에서 더 견고한 정리 메커니즘이 적용되어 안정적으로 종료됩니다.
  * 오류 처리 및 보고 메커니즘이 개선되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->