### PR TITLE
feat(kr-fundamentals): 연간 사업보고서 + DART 캐싱 + 재시도 백오프

### DIFF
--- a/src/data_client/korean/dart_client.py
+++ b/src/data_client/korean/dart_client.py
@@ -1,0 +1,313 @@
+"""DART OpenDartReader thin wrapper — shared by fundamentals/news/RAG sources.
+
+Wraps the third-party ``OpenDartReader`` so the rest of the data layer never
+imports it directly. Adds three concerns the bare client lacks:
+
+1. **Singleton lifecycle.** OpenDartReader downloads ``corp_code.xml`` (~5 MB)
+   on construction and caches it in process memory. Re-instantiating per
+   request would burn a few seconds of every overview load, so the client is
+   built once on first use and reused. Lock + double-checked init prevents
+   concurrent ``/overview`` requests from each paying that cost.
+
+2. **Redis-backed result cache.** ``finstate_all`` responses are immutable
+   once a filing is published — Q3 2024 will not retroactively change. We
+   cache the **extracted** values (six floats per row) rather than the raw
+   DataFrame so the cached payload is small and the cache key never has to
+   embed schema details. TTL is long for prior years (365 d) and short for
+   the current year (1 d) since new quarters file mid-year.
+
+3. **Retry + exponential backoff.** DART's free-tier API hiccups occasionally
+   on transient network or rate-limit conditions. Single failures used to
+   leave a quarter blank in the response; three retries with 1 s/2 s/4 s
+   backoff masks all the cases we have actually observed in production.
+
+The fundamentals source consumes only :func:`fetch_finstate_extracted` — the
+singleton and accounts constants are intentionally not part of the public
+surface so future callers stay decoupled from OpenDartReader.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import threading
+import time
+from datetime import datetime
+from typing import Any
+from zoneinfo import ZoneInfo
+
+import pandas as pd
+
+from src.utils.cache.redis_cache import get_cache_client
+
+logger = logging.getLogger(__name__)
+
+_KST = ZoneInfo("Asia/Seoul")
+
+# ---------------------------------------------------------------------------
+# Account matching (XBRL account_id primary, account_nm substring fallback)
+# ---------------------------------------------------------------------------
+
+_REVENUE_IDS = (
+    "ifrs-full_Revenue",
+    "ifrs-full_RevenueFromContractsWithCustomers",
+)
+_REVENUE_KEYWORDS = ("매출액", "수익(매출액)", "영업수익")
+
+_OPERATING_INCOME_IDS = ("dart_OperatingIncomeLoss",)
+_OPERATING_INCOME_KEYWORDS = ("영업이익",)
+
+_NET_INCOME_IDS = ("ifrs-full_ProfitLoss",)
+_NET_INCOME_KEYWORDS = ("당기순이익", "분기순이익", "반기순이익")
+
+_OPERATING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInOperatingActivities",)
+_OPERATING_CF_KEYWORDS = ("영업활동현금흐름", "영업활동으로 인한 현금흐름")
+
+_INVESTING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInInvestingActivities",)
+_INVESTING_CF_KEYWORDS = ("투자활동현금흐름", "투자활동으로 인한 현금흐름")
+
+_FINANCING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInFinancingActivities",)
+_FINANCING_CF_KEYWORDS = ("재무활동현금흐름", "재무활동으로 인한 현금흐름")
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+# Lock + double-checked init: concurrent /overview requests in to_thread can
+# all hit _get_dart_client in parallel. Without the lock, threads racing the
+# init could see ``init_attempted=True`` while ``singleton`` was still being
+# constructed by another thread — and receive ``None`` instead of waiting.
+_dart_singleton: Any | None = None
+_dart_init_attempted: bool = False
+_dart_init_lock = threading.Lock()
+
+
+def _get_dart_client() -> Any | None:
+    """Lazy singleton OpenDartReader. ``None`` if API key missing or import fails."""
+    global _dart_singleton, _dart_init_attempted
+    if _dart_init_attempted:
+        return _dart_singleton
+    with _dart_init_lock:
+        if _dart_init_attempted:
+            return _dart_singleton
+        api_key = os.getenv("DART_API_KEY")
+        if not api_key:
+            logger.info("dart.no_api_key")
+            _dart_singleton = None
+        else:
+            try:
+                import OpenDartReader  # noqa: N813 — package name is camelCase
+                _dart_singleton = OpenDartReader(api_key)
+            except Exception:
+                logger.warning("dart.client_init.failed", exc_info=True)
+                _dart_singleton = None
+        _dart_init_attempted = True
+    return _dart_singleton
+
+
+def reset_singleton_for_test() -> None:
+    """Test-only: clear the cached client so the next call re-inits."""
+    global _dart_singleton, _dart_init_attempted
+    with _dart_init_lock:
+        _dart_singleton = None
+        _dart_init_attempted = False
+
+
+# ---------------------------------------------------------------------------
+# Value extraction
+# ---------------------------------------------------------------------------
+
+
+def _safe_float(value: Any) -> float | None:
+    """Coerce to float. None for NaN / None / non-numeric.
+
+    DART finstate_all 의 ``thstrm_amount`` 는 천단위 콤마 string
+    ("79,140,503,000,000") 이므로 strip 후 파싱.
+    """
+    if value is None:
+        return None
+    if isinstance(value, str):
+        value = value.replace(",", "").strip()
+        if not value or value == "-":
+            return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    if f != f:  # NaN
+        return None
+    return f
+
+
+def _row_cumulative_amount(row: pd.Series) -> float | None:
+    """Pick the "cumulative-since-year-start" amount, normalizing IS/CF schema.
+
+    * IS (분기보고서): ``thstrm_amount`` = 단일 분기 (3M),
+      ``thstrm_add_amount`` = 누적. → add_amount 우선.
+    * IS (Q1 분기보고서): ``thstrm_add_amount`` 빈 값 → amount 가 곧 누적.
+    * CF / BS: ``thstrm_add_amount`` NaN → amount 사용.
+    """
+    add_val = _safe_float(row.get("thstrm_add_amount"))
+    if add_val is not None:
+        return add_val
+    return _safe_float(row.get("thstrm_amount"))
+
+
+def _extract_dart_amount(
+    df: pd.DataFrame,
+    account_ids: tuple[str, ...] = (),
+    account_keywords: tuple[str, ...] = (),
+    sj_divs: tuple[str, ...] = ("IS", "CIS", "CF"),
+) -> float | None:
+    """First matching row's cumulative amount, or ``None``.
+
+    Match priority: ``account_id`` exact (XBRL/IFRS standard, robust
+    cross-issuer) → ``account_nm`` substring (K-GAAP fallback). Schema
+    changes / missing columns degrade to ``None`` rather than raise — direct
+    indexing would propagate KeyError into a 500 from /overview.
+    """
+    if df is None or not isinstance(df, pd.DataFrame) or df.empty:
+        return None
+    if "thstrm_amount" not in df.columns:
+        return None
+
+    candidates = df[df["sj_div"].isin(sj_divs)] if "sj_div" in df.columns else df
+    if "fs_div" in candidates.columns:
+        cfs = candidates[candidates["fs_div"] == "CFS"]
+        if not cfs.empty:
+            candidates = cfs
+
+    if account_ids and "account_id" in candidates.columns:
+        for aid in account_ids:
+            matches = candidates[candidates["account_id"] == aid]
+            if not matches.empty:
+                return _row_cumulative_amount(matches.iloc[0])
+
+    if account_keywords and "account_nm" in candidates.columns:
+        for kw in account_keywords:
+            for _, row in candidates.iterrows():
+                if kw in str(row.get("account_nm", "")):
+                    return _row_cumulative_amount(row)
+    return None
+
+
+def _extract_all(df: pd.DataFrame) -> dict[str, float | None]:
+    """Extract the six fundamentals/cashflow values from one finstate_all df."""
+    return {
+        "revenue": _extract_dart_amount(df, _REVENUE_IDS, _REVENUE_KEYWORDS, sj_divs=("IS", "CIS")),
+        "operatingIncome": _extract_dart_amount(df, _OPERATING_INCOME_IDS, _OPERATING_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
+        "netIncome": _extract_dart_amount(df, _NET_INCOME_IDS, _NET_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
+        "operatingCashFlow": _extract_dart_amount(df, _OPERATING_CF_IDS, _OPERATING_CF_KEYWORDS, sj_divs=("CF",)),
+        "investingCashFlow": _extract_dart_amount(df, _INVESTING_CF_IDS, _INVESTING_CF_KEYWORDS, sj_divs=("CF",)),
+        "financingCashFlow": _extract_dart_amount(df, _FINANCING_CF_IDS, _FINANCING_CF_KEYWORDS, sj_divs=("CF",)),
+    }
+
+
+# ---------------------------------------------------------------------------
+# Cache + retry layer
+# ---------------------------------------------------------------------------
+
+# Past years' filings never change once published — cache aggressively.
+_TTL_PAST_YEAR_S = 365 * 24 * 3600  # 1 year
+# Current year's filings can land mid-year — re-check daily.
+_TTL_CURRENT_YEAR_S = 24 * 3600
+# Negative cache windows. Keep current-year shorter so a missing Q3 that gets
+# filed shows up in the next overview load instead of waiting a full day.
+_NEG_TTL_PAST_YEAR_S = 7 * 24 * 3600
+_NEG_TTL_CURRENT_YEAR_S = 60 * 60  # 1 hour
+
+_RETRY_BACKOFF_S = (1.0, 2.0, 4.0)
+
+
+def _ttl_for(year: int, has_data: bool) -> int:
+    current_year = datetime.now(_KST).year
+    is_past = year < current_year
+    if has_data:
+        return _TTL_PAST_YEAR_S if is_past else _TTL_CURRENT_YEAR_S
+    return _NEG_TTL_PAST_YEAR_S if is_past else _NEG_TTL_CURRENT_YEAR_S
+
+
+def _cache_key(stock_code: str, year: int, reprt_code: str, fs_div: str) -> str:
+    return f"dart:finstate:{stock_code}:{year}:{reprt_code}:{fs_div}"
+
+
+def _call_finstate_all_with_retry(
+    dart: Any, stock_code: str, year: int, reprt_code: str, fs_div: str,
+) -> pd.DataFrame | None:
+    """Synchronous DART call with exponential backoff. Off-loaded via to_thread.
+
+    Returns the raw DataFrame on success, ``None`` if all retries fail. Empty
+    DataFrame (no row matches the filing) is treated as success — distinct
+    from "transient error" so we cache it as a negative result.
+    """
+    last_exc: Exception | None = None
+    for attempt, delay in enumerate((0.0, *_RETRY_BACKOFF_S)):
+        if delay:
+            # The function runs in a worker thread (to_thread); time.sleep is
+            # the right primitive here, not asyncio.sleep.
+            time.sleep(delay)
+        try:
+            return dart.finstate_all(stock_code, year, reprt_code=reprt_code, fs_div=fs_div)
+        except Exception as exc:
+            last_exc = exc
+            logger.warning(
+                "dart.finstate_all.retry | corp=%s year=%s reprt=%s attempt=%s err=%s",
+                stock_code, year, reprt_code, attempt + 1, exc,
+            )
+    logger.warning(
+        "dart.finstate_all.exhausted | corp=%s year=%s reprt=%s last_err=%s",
+        stock_code, year, reprt_code, last_exc,
+    )
+    return None
+
+
+_EMPTY_EXTRACT: dict[str, float | None] = {
+    "revenue": None,
+    "operatingIncome": None,
+    "netIncome": None,
+    "operatingCashFlow": None,
+    "investingCashFlow": None,
+    "financingCashFlow": None,
+}
+
+
+async def fetch_finstate_extracted(
+    stock_code: str,
+    year: int,
+    reprt_code: str,
+    fs_div: str = "CFS",
+) -> dict[str, float | None] | None:
+    """Return extracted DART values for one (corp, year, reprt) — cached.
+
+    Cache layer (Redis, JSON):
+
+    * HIT  → return the six-key dict directly, no DART hit.
+    * MISS → call ``finstate_all`` (with retry), extract, cache, return.
+
+    Returns ``None`` only when the DART client is not configured
+    (``DART_API_KEY`` missing). Genuine "no data" answers from DART are
+    represented as a dict whose values are all ``None`` — distinguishing
+    "DART says nothing here" (cacheable) from "we never asked" (not).
+    """
+    dart = _get_dart_client()
+    if dart is None:
+        return None
+
+    cache = get_cache_client()
+    key = _cache_key(stock_code, year, reprt_code, fs_div)
+    cached = await cache.get(key)
+    if cached is not None and isinstance(cached, dict):
+        return cached
+
+    df = await asyncio.to_thread(
+        _call_finstate_all_with_retry, dart, stock_code, year, reprt_code, fs_div,
+    )
+    if df is None:
+        # All retries failed — do NOT cache so the next call retries.
+        return _EMPTY_EXTRACT.copy()
+
+    extracted = _extract_all(df) if not df.empty else _EMPTY_EXTRACT.copy()
+    has_data = any(v is not None for v in extracted.values())
+    await cache.set(key, extracted, ttl=_ttl_for(year, has_data))
+    return extracted

--- a/src/data_client/korean/dart_client.py
+++ b/src/data_client/korean/dart_client.py
@@ -107,11 +107,12 @@ def _get_dart_client() -> Any | None:
 
 
 def reset_singleton_for_test() -> None:
-    """Test-only: clear the cached client so the next call re-inits."""
+    """Test-only: clear the cached client + in-flight table so the next call re-inits."""
     global _dart_singleton, _dart_init_attempted
     with _dart_init_lock:
         _dart_singleton = None
         _dart_init_attempted = False
+    _inflight.clear()
 
 
 # ---------------------------------------------------------------------------
@@ -272,18 +273,27 @@ _EMPTY_EXTRACT: dict[str, float | None] = {
 }
 
 
+# In-flight dedup: concurrent ``fetch_finstate_extracted`` calls for the same
+# (stock, year, reprt, fs_div) share one asyncio.Task. ``get_overview`` runs
+# ``_fetch_dart_quarterlies`` and ``_fetch_dart_annuals`` in parallel, and
+# their FY (11011) requests for the same year would otherwise both MISS the
+# Redis cache and dispatch separate DART hits. The dedup table is module-
+# scoped — see ``reset_singleton_for_test`` for the test reset hook.
+_inflight: dict[str, asyncio.Task[dict[str, float | None] | None]] = {}
+
+
 async def fetch_finstate_extracted(
     stock_code: str,
     year: int,
     reprt_code: str,
     fs_div: str = "CFS",
 ) -> dict[str, float | None] | None:
-    """Return extracted DART values for one (corp, year, reprt) — cached.
+    """Return extracted DART values for one (corp, year, reprt) — cached + deduped.
 
-    Cache layer (Redis, JSON):
-
-    * HIT  → return the six-key dict directly, no DART hit.
-    * MISS → call ``finstate_all`` (with retry), extract, cache, return.
+    * Cache HIT (Redis) → return the six-key dict directly, no DART hit.
+    * Cache MISS, in-flight HIT → await the existing fetch task.
+    * Cache MISS, no in-flight → call ``finstate_all`` (with retry), extract,
+      cache, return.
 
     Returns ``None`` only when the DART client is not configured
     (``DART_API_KEY`` missing). Genuine "no data" answers from DART are
@@ -300,14 +310,30 @@ async def fetch_finstate_extracted(
     if cached is not None and isinstance(cached, dict):
         return cached
 
-    df = await asyncio.to_thread(
-        _call_finstate_all_with_retry, dart, stock_code, year, reprt_code, fs_div,
-    )
-    if df is None:
-        # All retries failed — do NOT cache so the next call retries.
-        return _EMPTY_EXTRACT.copy()
+    # In-flight dedup. Single-loop asyncio: the dict check + insert below run
+    # without yielding, so two concurrent callers that miss the cache will
+    # serialize on the dict and the second sees the first's task.
+    existing = _inflight.get(key)
+    if existing is not None:
+        # ``shield`` so a cancellation in this caller doesn't cancel the
+        # underlying task that another concurrent caller may also be awaiting.
+        return await asyncio.shield(existing)
 
-    extracted = _extract_all(df) if not df.empty else _EMPTY_EXTRACT.copy()
-    has_data = any(v is not None for v in extracted.values())
-    await cache.set(key, extracted, ttl=_ttl_for(year, has_data))
-    return extracted
+    async def _fetch_and_cache() -> dict[str, float | None]:
+        df = await asyncio.to_thread(
+            _call_finstate_all_with_retry, dart, stock_code, year, reprt_code, fs_div,
+        )
+        if df is None:
+            # All retries failed — do NOT cache so the next call retries.
+            return _EMPTY_EXTRACT.copy()
+        extracted = _extract_all(df) if not df.empty else _EMPTY_EXTRACT.copy()
+        has_data = any(v is not None for v in extracted.values())
+        await cache.set(key, extracted, ttl=_ttl_for(year, has_data))
+        return extracted
+
+    task = asyncio.create_task(_fetch_and_cache())
+    _inflight[key] = task
+    try:
+        return await asyncio.shield(task)
+    finally:
+        _inflight.pop(key, None)

--- a/src/data_client/korean/fundamentals_source.py
+++ b/src/data_client/korean/fundamentals_source.py
@@ -1,4 +1,4 @@
-"""KR fundamentals — quote / performance / quarterly financials for KOSPI/KOSDAQ.
+"""KR fundamentals — quote / performance / quarterly + annual financials for KOSPI/KOSDAQ.
 
 FORK (#42):
 * Quote (시가총액 / 52W / dayHigh-Low / shares): yfinance ``fast_info`` 사용.
@@ -6,10 +6,12 @@ FORK (#42):
   구조 변경으로 현재 KeyError 발생 — yfinance fast_info 가 KR ticker 도 안정적
   으로 처리.
 * Performance (1D / 5D / 1M / 3M / 6M / 1Y / YTD %): pykrx OHLCV 로 계산.
-* Quarterly fundamentals (revenue / operating income / net income) +
-  cashFlow (operating / investing / financing): DART finstate 누적 보고서
-  4개 (Q1 / H1 / 9M / FY) 를 가져와 차분으로 단일 분기 환산. ``DART_API_KEY``
-  미설정·요청 실패 시 None 으로 fallback — quote/performance 는 정상 응답.
+* Quarterly fundamentals + cashFlow: DART finstate 누적 보고서 4개
+  (Q1 / H1 / 9M / FY) 를 가져와 차분으로 단일 분기 환산.
+* Annual fundamentals + cashFlow (#52): DART FY (11011) 만 N 년치 가져와
+  연도별 시계열로 노출. 5년 trend 쿼리가 5×4 → 5×1 호출로 절감.
+* DART 호출은 ``dart_client.fetch_finstate_extracted`` 경유 — Redis 캐시 +
+  exponential backoff 재시도. ``DART_API_KEY`` 미설정·요청 실패 시 None.
 * PER / PBR / EPS / 배당 / analystRatings / revenueByProduct·Geo: 별도 issue.
 """
 
@@ -17,15 +19,14 @@ from __future__ import annotations
 
 import asyncio
 import logging
-import os
-import threading
 from datetime import datetime, timedelta
 from typing import Any
 from zoneinfo import ZoneInfo
 
-import pandas as pd
 import yfinance as yf
 from pykrx import stock
+
+from src.data_client.korean.dart_client import fetch_finstate_extracted
 
 logger = logging.getLogger(__name__)
 
@@ -43,7 +44,6 @@ _PERIOD_BUSINESS_DAYS: dict[str, int] = {
 }
 
 # DART 보고서 코드 — Q1=11013, H1=11012(누적), 3Q=11014(누적), FY=11011(누적).
-# H1·9M·FY 는 누적치이므로 단일 분기 환산은 차분(subtraction) 필요.
 _DART_REPRT_CODES: list[tuple[str, str]] = [
     ("Q1", "11013"),
     ("H1", "11012"),
@@ -53,29 +53,12 @@ _DART_REPRT_CODES: list[tuple[str, str]] = [
 _DART_PREV_LABEL = {"H1": "Q1", "9M": "H1", "FY": "9M"}
 _DART_QUARTER_LABEL = {"Q1": "Q1", "H1": "Q2", "9M": "Q3", "FY": "Q4"}
 
-# 계정 매칭 — 우선 XBRL ``account_id`` (IFRS/DART 표준 ID, 회사간 안정) 으로
-# 매칭하고, 누락 시 ``account_nm`` substring 매칭으로 fallback (K-GAAP 등).
-# Tuple 안 순서 = 우선순위.
-_REVENUE_IDS = (
-    "ifrs-full_Revenue",
-    "ifrs-full_RevenueFromContractsWithCustomers",
-)
-_REVENUE_KEYWORDS = ("매출액", "수익(매출액)", "영업수익")
+# Annual lookback default — 5년 전부터 직전 FY 까지. 요청 시 confirm 안 된 데이터
+# (당해 FY 미공시) 는 자연스럽게 빠지므로 caller 가 별도 필터 안 해도 됨.
+_ANNUAL_LOOKBACK_YEARS = 5
 
-_OPERATING_INCOME_IDS = ("dart_OperatingIncomeLoss",)
-_OPERATING_INCOME_KEYWORDS = ("영업이익",)
-
-_NET_INCOME_IDS = ("ifrs-full_ProfitLoss",)
-_NET_INCOME_KEYWORDS = ("당기순이익", "분기순이익", "반기순이익")
-
-_OPERATING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInOperatingActivities",)
-_OPERATING_CF_KEYWORDS = ("영업활동현금흐름", "영업활동으로 인한 현금흐름")
-
-_INVESTING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInInvestingActivities",)
-_INVESTING_CF_KEYWORDS = ("투자활동현금흐름", "투자활동으로 인한 현금흐름")
-
-_FINANCING_CF_IDS = ("ifrs-full_CashFlowsFromUsedInFinancingActivities",)
-_FINANCING_CF_KEYWORDS = ("재무활동현금흐름", "재무활동으로 인한 현금흐름")
+_FUNDAMENTAL_KEYS = ("revenue", "operatingIncome", "netIncome")
+_CASHFLOW_KEYS = ("operatingCashFlow", "investingCashFlow", "financingCashFlow")
 
 
 def _strip_suffix(symbol: str) -> str:
@@ -87,11 +70,6 @@ def _strip_suffix(symbol: str) -> str:
 
 
 def _safe_float(value: Any) -> float | None:
-    """Coerce to float. None for NaN / None / non-numeric.
-
-    DART finstate 의 ``thstrm_amount`` 는 천단위 콤마 string ("79,140,503,000,000")
-    이므로 strip 후 파싱.
-    """
     if value is None:
         return None
     if isinstance(value, str):
@@ -142,7 +120,6 @@ def _fetch_quote_from_yf(yahoo_symbol: str) -> dict[str, Any]:
 def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
     """pykrx OHLCV 로 7개 period % 계산. 거래일 부족 시 해당 period 만 None."""
     today_kst = datetime.now(_KST)
-    # 1Y + 여유 30일 lookback — 252 영업일 + 휴일 buffer.
     start_date = today_kst - timedelta(days=int(252 * 1.6))
     start = start_date.strftime("%Y%m%d")
     end = today_kst.strftime("%Y%m%d")
@@ -165,7 +142,6 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
 
     perf: dict[str, float | None] = {}
     for label, lookback_bd in _PERIOD_BUSINESS_DAYS.items():
-        # iloc[-1] 이 today, 그 이전 lookback_bd 번째 종가와 비교.
         if len(closes) <= lookback_bd:
             perf[label] = None
             continue
@@ -175,7 +151,6 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
             continue
         perf[label] = round((last_close - ref) / ref * 100, 4)
 
-    # YTD: 올해 첫 거래일 종가 기준.
     year = today_kst.year
     ytd_mask = df.index.year == year
     if ytd_mask.any():
@@ -192,169 +167,48 @@ def _fetch_performance_from_pykrx(ticker: str) -> dict[str, float | None]:
 
 
 # ---------------------------------------------------------------------------
-# DART 분기 재무제표 — quarterlyFundamentals + cashFlow
+# DART 분기/연간 재무
 # ---------------------------------------------------------------------------
 
-# OpenDartReader 인스턴스는 corp_code XML(~5MB) 을 첫 호출에 download → 메모리 캐시.
-# /overview latency 보호 위해 모듈 싱글톤 — DART_API_KEY 미설정 시 None 반환.
-# Lock + double-checked init: 동시 /overview 요청이 to_thread 에서 동시에 들어오면
-# init 중인 thread 외 다른 thread 가 init_attempted=True 만 보고 미완성 None 받는
-# race 방지 — 첫 thread 가 OpenDartReader instantiate (수초 소요) 끝낼 때까지 wait.
-_dart_singleton: Any | None = None
-_dart_init_attempted: bool = False
-_dart_init_lock = threading.Lock()
 
-
-def _get_dart_client() -> Any | None:
-    """Lazy singleton OpenDartReader. ``None`` if API key missing or import fails."""
-    global _dart_singleton, _dart_init_attempted
-    if _dart_init_attempted:
-        return _dart_singleton
-    with _dart_init_lock:
-        # double-check: 다른 thread 가 lock 안에서 이미 init 끝냈을 수 있음.
-        if _dart_init_attempted:
-            return _dart_singleton
-        api_key = os.getenv("DART_API_KEY")
-        if not api_key:
-            logger.info("kr_fundamentals.dart.no_api_key")
-            _dart_singleton = None
-        else:
-            try:
-                import OpenDartReader  # noqa: N813 — package name is camelCase
-                _dart_singleton = OpenDartReader(api_key)
-            except Exception:
-                logger.warning("kr_fundamentals.dart.client_init.failed", exc_info=True)
-                _dart_singleton = None
-        # init 완전히 끝난 후 flag — 미완성 상태 노출 안 됨.
-        _dart_init_attempted = True
-    return _dart_singleton
-
-
-def _row_cumulative_amount(row: pd.Series) -> float | None:
-    """누적치 추출 — DART finstate_all 의 sj_div 별 컬럼 의미 차이 정규화.
-
-    * IS (분기보고서) : ``thstrm_amount`` = 해당 분기 단독 (3M),
-      ``thstrm_add_amount`` = 연초부터 누적. → add_amount 우선.
-    * IS (사업보고서/Q1) : ``thstrm_add_amount`` 빈 값 → amount 가 곧 누적.
-    * CF / BS : ``thstrm_add_amount`` 가 NaN → amount 사용.
-
-    이 정규화로 모든 row 가 "연초부터 누적" 의미를 갖게 되어 차분 logic 단순화.
-    """
-    # add_amount = 0 도 valid (해당 분기 누적이 정확히 0 인 항목 — 드물지만 가능).
-    # `_safe_float` 가 None / NaN / 빈 문자열을 None 으로 정규화하므로
-    # is-not-None 만으로 missing 판정 충분.
-    add_val = _safe_float(row.get("thstrm_add_amount"))
-    if add_val is not None:
-        return add_val
-    return _safe_float(row.get("thstrm_amount"))
-
-
-def _extract_dart_amount(
-    df: pd.DataFrame,
-    account_ids: tuple[str, ...] = (),
-    account_keywords: tuple[str, ...] = (),
-    sj_divs: tuple[str, ...] = ("IS", "CIS", "CF"),
-) -> float | None:
-    """DART finstate_all DataFrame 에서 첫 매칭 row 의 누적금액 반환.
-
-    매칭 우선순위:
-    1. ``account_id`` exact match (IFRS / DART 표준 ID — 회사간 안정)
-    2. ``account_nm`` substring match (XBRL ID 없는 K-GAAP 회사 fallback)
-
-    값 추출은 ``_row_cumulative_amount`` — IS / CF schema 차이 정규화.
-    schema 변경 / 누락 column 모두 None 으로 안전 처리 — 직접 인덱싱은
-    KeyError 로 /overview 전체 500 으로 번질 수 있음.
-    """
-    if df is None or not isinstance(df, pd.DataFrame) or df.empty:
-        return None
-    if "thstrm_amount" not in df.columns:
-        return None
-
-    candidates = df[df["sj_div"].isin(sj_divs)] if "sj_div" in df.columns else df
-    # finstate (legacy) 는 fs_div column 으로 CFS/OFS 혼재 — CFS 우선.
-    # finstate_all 은 한 호출당 한 fs_div 라 column 자체가 없음.
-    if "fs_div" in candidates.columns:
-        cfs = candidates[candidates["fs_div"] == "CFS"]
-        if not cfs.empty:
-            candidates = cfs
-
-    if account_ids and "account_id" in candidates.columns:
-        for aid in account_ids:
-            matches = candidates[candidates["account_id"] == aid]
-            if not matches.empty:
-                return _row_cumulative_amount(matches.iloc[0])
-
-    if account_keywords and "account_nm" in candidates.columns:
-        for kw in account_keywords:
-            for _, row in candidates.iterrows():
-                if kw in str(row.get("account_nm", "")):
-                    return _row_cumulative_amount(row)
-    return None
-
-
-def _fetch_dart_quarterlies(
+async def _fetch_dart_quarterlies(
     stock_code: str,
 ) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
-    """DART 분기 재무로 (quarterlyFundamentals, cashFlow) 도출. 최근 4개 분기.
+    """Last 4 quarters of (fundamentals, cashflow) by differencing cumulative DART reports.
 
-    DART 의 H1/9M/FY thstrm_amount 는 누적치 — 직전 누적 빼서 단일 분기 환산.
-    직전 보고서가 없으면 (예: H1 만 공시되고 Q1 누락) 해당 분기 skip.
-
-    Returns
-    -------
-    fundamentals : list[{period, revenue, operatingIncome, netIncome}]
-    cashflow : list[{period, operatingCashFlow, investingCashFlow, financingCashFlow}]
-
-    DART 미설정 / 모든 보고서 fetch 실패 시 ``([], [])``.
+    Each quarter's single-period figure = current cumulative − previous cumulative
+    (Q1 is itself single-period). Reports are fetched in parallel through
+    ``dart_client.fetch_finstate_extracted`` so the whole grid (3 years × 4
+    reports = up to 12 calls) hits Redis at most once per (year, reprt) and
+    backs off on transient DART failures.
     """
-    dart = _get_dart_client()
-    if dart is None:
-        return [], []
-
     today = datetime.now(_KST)
     # 직전 2년 + 당해 — 연초 (예: 1~3월) 에는 직전 해 FY 미공시라 (마감 90일 전)
     # 직전-1 의 Q4 까지 거슬러 올라가야 quarters[-4:] 가 4개 채워짐.
     years = (today.year - 2, today.year - 1, today.year)
 
+    grid_keys = [(year, label, code) for year in years for label, code in _DART_REPRT_CODES]
+    extracted_list = await asyncio.gather(
+        *(fetch_finstate_extracted(stock_code, year, code) for year, _label, code in grid_keys),
+    )
     cumulative: dict[tuple[int, str], dict[str, float | None]] = {}
-    for year in years:
-        for label, reprt_code in _DART_REPRT_CODES:
-            try:
-                # finstate (key items) 는 CF rows 가 없어서 cashFlow 채울 수 없음.
-                # finstate_all 은 XBRL 전체 항목 + account_id 까지 포함 — IFRS 표준 ID
-                # 매칭으로 회사간 robust. 기본 fs_div='CFS' (연결재무제표).
-                df = dart.finstate_all(stock_code, year, reprt_code=reprt_code)
-            except Exception:
-                logger.warning(
-                    "kr_fundamentals.dart.finstate_all.failed | corp=%s year=%s reprt=%s",
-                    stock_code, year, reprt_code, exc_info=True,
-                )
-                continue
-            if df is None or not isinstance(df, pd.DataFrame) or df.empty:
-                continue
-            cumulative[(year, label)] = {
-                "revenue": _extract_dart_amount(df, _REVENUE_IDS, _REVENUE_KEYWORDS, sj_divs=("IS", "CIS")),
-                "operatingIncome": _extract_dart_amount(df, _OPERATING_INCOME_IDS, _OPERATING_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
-                "netIncome": _extract_dart_amount(df, _NET_INCOME_IDS, _NET_INCOME_KEYWORDS, sj_divs=("IS", "CIS")),
-                "operatingCashFlow": _extract_dart_amount(df, _OPERATING_CF_IDS, _OPERATING_CF_KEYWORDS, sj_divs=("CF",)),
-                "investingCashFlow": _extract_dart_amount(df, _INVESTING_CF_IDS, _INVESTING_CF_KEYWORDS, sj_divs=("CF",)),
-                "financingCashFlow": _extract_dart_amount(df, _FINANCING_CF_IDS, _FINANCING_CF_KEYWORDS, sj_divs=("CF",)),
-            }
-
-    if not cumulative:
-        return [], []
+    for (year, label, _code), extracted in zip(grid_keys, extracted_list, strict=True):
+        if extracted is None:
+            # DART_API_KEY 미설정 — 한 번이라도 None 이면 모두 None (전체 fail).
+            return [], []
+        cumulative[(year, label)] = extracted
 
     quarters: list[dict[str, Any]] = []
     period_sequence = [(y, lbl) for y in sorted(years) for lbl, _ in _DART_REPRT_CODES]
     for year, label in period_sequence:
         cum = cumulative.get((year, label))
-        if cum is None:
+        if cum is None or all(cum[k] is None for k in cum):
             continue
         if label == "Q1":
             single = dict(cum)
         else:
             prev = cumulative.get((year, _DART_PREV_LABEL[label]))
-            if prev is None:
+            if prev is None or all(prev[k] is None for k in prev):
                 continue
             single = {
                 k: (cum[k] - prev[k]) if (cum[k] is not None and prev[k] is not None) else None
@@ -364,25 +218,46 @@ def _fetch_dart_quarterlies(
         quarters.append({"period": period, **single})
 
     quarters = quarters[-4:]
-
     fundamentals = [
-        {
-            "period": q["period"],
-            "revenue": q["revenue"],
-            "operatingIncome": q["operatingIncome"],
-            "netIncome": q["netIncome"],
-        }
-        for q in quarters
+        {"period": q["period"], **{k: q[k] for k in _FUNDAMENTAL_KEYS}} for q in quarters
     ]
     cashflow = [
-        {
-            "period": q["period"],
-            "operatingCashFlow": q["operatingCashFlow"],
-            "investingCashFlow": q["investingCashFlow"],
-            "financingCashFlow": q["financingCashFlow"],
-        }
-        for q in quarters
+        {"period": q["period"], **{k: q[k] for k in _CASHFLOW_KEYS}} for q in quarters
     ]
+    return fundamentals, cashflow
+
+
+async def _fetch_dart_annuals(
+    stock_code: str, lookback_years: int = _ANNUAL_LOOKBACK_YEARS,
+) -> tuple[list[dict[str, Any]], list[dict[str, Any]]]:
+    """Annual fundamentals + cashflow for the last ``lookback_years`` years.
+
+    Uses only the FY (사업보고서, ``reprt_code=11011``) report — its
+    ``thstrm_amount`` is itself the year cumulative, so no differencing.
+    Years with no FY filed yet (current year before annual release) are
+    silently dropped, so callers never need to filter empty rows.
+    """
+    today = datetime.now(_KST)
+    years = list(range(today.year - lookback_years, today.year + 1))
+    extracted_list = await asyncio.gather(
+        *(fetch_finstate_extracted(stock_code, year, "11011") for year in years),
+    )
+    fundamentals: list[dict[str, Any]] = []
+    cashflow: list[dict[str, Any]] = []
+    for year, extracted in zip(years, extracted_list, strict=True):
+        if extracted is None:
+            return [], []
+        # Drop years where every value is None (typically future years with no
+        # filing yet) — leaves a clean year-keyed series.
+        if all(extracted[k] is None for k in extracted):
+            continue
+        period = str(year)
+        fundamentals.append(
+            {"period": period, **{k: extracted[k] for k in _FUNDAMENTAL_KEYS}}
+        )
+        cashflow.append(
+            {"period": period, **{k: extracted[k] for k in _CASHFLOW_KEYS}}
+        )
     return fundamentals, cashflow
 
 
@@ -392,7 +267,7 @@ def _fetch_dart_quarterlies(
 
 
 class KoreanFundamentalsSource:
-    """quote + performance + quarterly fundamentals/cashFlow for KR ticker (.KS / .KQ).
+    """quote + performance + quarterly/annual fundamentals + cashFlow for KR ticker.
 
     revenueByProduct / revenueByGeo / earningsSurprises / analyst consensus 는
     별도 source — XBRL 본문 파싱 (segment) / 별도 컨센서스 데이터 필요.
@@ -400,30 +275,29 @@ class KoreanFundamentalsSource:
 
     @staticmethod
     def supports(symbol: str) -> bool:
-        # is_unsupported_analyst_market / _is_kr_symbol 와 동일하게 strip + upper 정규화.
         return symbol.strip().upper().endswith(_KR_SUFFIXES)
 
     async def get_overview(self, symbol: str) -> dict[str, Any]:
         """Return CompanyOverviewResponse 호환 dict (KR 채울 수 있는 부분만).
 
-        외부 호출 (yfinance + pykrx + DART) 은 ``asyncio.to_thread`` 로 wrap +
-        ``asyncio.gather`` 로 병렬. DART 미설정·실패는 fundamentals/cashFlow
-        만 None 으로 graceful degrade — quote/performance 응답은 정상.
+        Quote / performance / quarterly DART / annual DART 4 paths run in
+        ``asyncio.gather`` — DART subgraphs deduplicate via the Redis cache
+        layer, so the annual call shares cache with the FY entries needed
+        for Q4 derivation.
         """
-        # FORK (#42): supports() / is_unsupported_analyst_market 와 동일하게 strip 먼저.
-        # 호출자가 이미 normalize 했더라도 source 자체가 raw input 안전 처리.
         symbol = symbol.strip()
         ticker = _strip_suffix(symbol)
         symbol_upper = symbol.upper()
 
-        quote, performance, dart_data = await asyncio.gather(
+        quote, performance, quarter_data, annual_data = await asyncio.gather(
             asyncio.to_thread(_fetch_quote_from_yf, symbol_upper),
             asyncio.to_thread(_fetch_performance_from_pykrx, ticker),
-            asyncio.to_thread(_fetch_dart_quarterlies, ticker),
+            _fetch_dart_quarterlies(ticker),
+            _fetch_dart_annuals(ticker),
         )
-        fundamentals, cashflow = dart_data
+        fundamentals, cashflow = quarter_data
+        annual_fundamentals, annual_cashflow = annual_data
 
-        # quote 가 비었으면 unsupported 와 동일 — caller 가 unsupported flag 다시 세움.
         if not quote:
             return {
                 "symbol": symbol_upper,
@@ -433,7 +307,6 @@ class KoreanFundamentalsSource:
                 "_partial": True,
             }
 
-        # name 은 yfinance fast_info 에 없음. Ticker.info 는 비싸서 생략.
         return {
             "symbol": symbol_upper,
             "name": None,
@@ -441,6 +314,8 @@ class KoreanFundamentalsSource:
             "performance": performance,
             "quarterlyFundamentals": fundamentals or None,
             "cashFlow": cashflow or None,
+            "annualFundamentals": annual_fundamentals or None,
+            "annualCashFlow": annual_cashflow or None,
             # 별도 issue — KR 컨센서스 source / XBRL segment 파싱 필요.
             "analystRatings": None,
             "earningsSurprises": None,

--- a/src/server/app/market_data.py
+++ b/src/server/app/market_data.py
@@ -540,6 +540,8 @@ async def get_company_overview(symbol: str, user_id: CurrentUserId) -> CompanyOv
                 quarterlyFundamentals=artifact.get("quarterlyFundamentals"),
                 earningsSurprises=artifact.get("earningsSurprises"),
                 cashFlow=artifact.get("cashFlow"),
+                annualFundamentals=artifact.get("annualFundamentals"),
+                annualCashFlow=artifact.get("annualCashFlow"),
                 revenueByProduct=artifact.get("revenueByProduct"),
                 revenueByGeo=artifact.get("revenueByGeo"),
             )

--- a/src/server/models/market_data.py
+++ b/src/server/models/market_data.py
@@ -216,6 +216,8 @@ class CompanyOverviewResponse(BaseModel):
     quarterlyFundamentals: Optional[List[Dict[str, Any]]] = Field(None, description="Quarterly revenue/income data")
     earningsSurprises: Optional[List[Dict[str, Any]]] = Field(None, description="EPS actual vs estimate")
     cashFlow: Optional[List[Dict[str, Any]]] = Field(None, description="Quarterly cash flow data")
+    annualFundamentals: Optional[List[Dict[str, Any]]] = Field(None, description="Annual revenue/income series")
+    annualCashFlow: Optional[List[Dict[str, Any]]] = Field(None, description="Annual cash flow series")
     revenueByProduct: Optional[Dict[str, Any]] = Field(None, description="Revenue breakdown by product")
     revenueByGeo: Optional[Dict[str, Any]] = Field(None, description="Revenue breakdown by geography")
     # FORK (#33): KR ticker (.KS / .KQ) 는 현재 fundamentals source 없음. unsupported=True 면

--- a/tests/unit/data_client/korean/test_dart_client.py
+++ b/tests/unit/data_client/korean/test_dart_client.py
@@ -373,3 +373,59 @@ async def test_fetch_finstate_extracted_cache_hit_skips_retry_path(monkeypatch, 
     assert result is not None
     assert result["revenue"] == 42.0
     fake_dart.finstate_all.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_concurrent_calls_for_same_key_dedupe_to_one_dart_hit(monkeypatch, fake_cache):
+    """Two concurrent callers for the same (stock, year, reprt) → single DART call.
+
+    Regression: ``get_overview`` runs ``_fetch_dart_quarterlies`` and
+    ``_fetch_dart_annuals`` in parallel; they overlap on FY (11011) for the
+    last few years. Without in-flight dedup, both miss Redis on cold cache
+    and dispatch separate DART calls for identical data.
+    """
+    import asyncio as _asyncio
+
+    # threading primitives — safe to set/check from both the worker thread
+    # (to_thread) and the asyncio main loop without cross-loop hops.
+    started = threading.Event()
+    proceed = threading.Event()
+    call_count = 0
+
+    successful_df = _build_finstate_df(100, 10, 8, 20, -15, -3)
+
+    def slow_finstate_all(*_args, **_kwargs):
+        # Runs in a worker thread (to_thread). Signal the test, then block
+        # until the test has launched the second caller and releases us.
+        nonlocal call_count
+        call_count += 1
+        started.set()
+        # Cap at 5s so a regression here surfaces as a test failure, not a
+        # CI hang.
+        proceed.wait(timeout=5.0)
+        return successful_df
+
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = slow_finstate_all
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    # Launch two concurrent fetches for the same key.
+    task_a = _asyncio.create_task(dc.fetch_finstate_extracted("005930", 2024, "11011"))
+    # Wait until the first caller has reached DART so task_b is guaranteed
+    # to see the in-flight entry rather than racing the cache. The worker
+    # thread runs in parallel; yield the loop until it sets started.
+    while not started.is_set():
+        await _asyncio.sleep(0.01)
+
+    task_b = _asyncio.create_task(dc.fetch_finstate_extracted("005930", 2024, "11011"))
+    # Give task_b one event-loop iteration to enter and discover the inflight entry.
+    await _asyncio.sleep(0)
+    proceed.set()
+
+    result_a, result_b = await _asyncio.gather(task_a, task_b)
+    assert result_a == result_b
+    assert result_a is not None
+    assert result_a["revenue"] == 100.0
+    assert call_count == 1, f"DART finstate_all called {call_count} times — dedup failed"
+    # In-flight table cleaned up after both callers resolved.
+    assert dc._cache_key("005930", 2024, "11011", "CFS") not in dc._inflight

--- a/tests/unit/data_client/korean/test_dart_client.py
+++ b/tests/unit/data_client/korean/test_dart_client.py
@@ -1,0 +1,375 @@
+"""Tests for src.data_client.korean.dart_client (#52).
+
+Covers three concerns the bare OpenDartReader doesn't:
+- Singleton lifecycle + concurrent init guard
+- Redis cache hit/miss with year-based TTL
+- Retry + exponential backoff (sleep mocked for speed)
+
+Tests for ``_extract_dart_amount`` / ``_safe_float`` / ``_row_cumulative_amount``
+also live here — the logic moved out of fundamentals_source as part of #52.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any
+from unittest.mock import AsyncMock, MagicMock
+
+import pandas as pd
+import pytest
+
+from src.data_client.korean import dart_client as dc
+
+
+@pytest.fixture(autouse=True)
+def _reset_dart_singleton(monkeypatch):
+    """Each test starts with a fresh client init slate."""
+    dc.reset_singleton_for_test()
+    yield
+    dc.reset_singleton_for_test()
+
+
+@pytest.fixture
+def fast_retry(monkeypatch):
+    """Skip real backoff sleeps so retry tests run in ms, not seconds."""
+    monkeypatch.setattr(dc.time, "sleep", lambda _s: None)
+
+
+# ---------------------------------------------------------------------------
+# Singleton
+# ---------------------------------------------------------------------------
+
+class TestGetDartClient:
+    def test_returns_none_without_api_key(self, monkeypatch):
+        monkeypatch.delenv("DART_API_KEY", raising=False)
+        assert dc._get_dart_client() is None
+        # Second call short-circuits via init_attempted flag — still None.
+        assert dc._get_dart_client() is None
+
+    def test_lock_prevents_concurrent_init_returning_none(self, monkeypatch):
+        """Two threads racing init must both receive the constructed client.
+
+        Regression: an earlier version flipped ``init_attempted`` *before*
+        ``OpenDartReader(...)`` returned, so a second thread mid-construction
+        saw ``None``.
+        """
+        monkeypatch.setenv("DART_API_KEY", "fake-key")
+        init_call_count = 0
+        init_started = threading.Event()
+        init_can_finish = threading.Event()
+
+        class SlowOpenDartReader:
+            def __init__(self, _key):
+                nonlocal init_call_count
+                init_call_count += 1
+                init_started.set()
+                init_can_finish.wait(timeout=2)
+
+        import sys
+        sys.modules["OpenDartReader"] = SlowOpenDartReader  # type: ignore[assignment]
+
+        results: list[Any] = []
+
+        def call_get_client():
+            results.append(dc._get_dart_client())
+
+        try:
+            t1 = threading.Thread(target=call_get_client)
+            t2 = threading.Thread(target=call_get_client)
+            t1.start()
+            init_started.wait(timeout=2)
+            t2.start()
+            init_can_finish.set()
+            t1.join(timeout=3)
+            t2.join(timeout=3)
+        finally:
+            del sys.modules["OpenDartReader"]
+
+        assert init_call_count == 1
+        assert all(r is not None for r in results), f"got None: {results}"
+        assert results[0] is results[1]
+
+
+# ---------------------------------------------------------------------------
+# _safe_float / _row_cumulative_amount / _extract_dart_amount
+# ---------------------------------------------------------------------------
+
+class TestSafeFloat:
+    def test_valid_numeric(self):
+        assert dc._safe_float(1.5) == 1.5
+        assert dc._safe_float(0) == 0.0
+        assert dc._safe_float("3.14") == 3.14
+
+    def test_none_returns_none(self):
+        assert dc._safe_float(None) is None
+
+    def test_nan_returns_none(self):
+        assert dc._safe_float(float("nan")) is None
+
+    def test_non_numeric_returns_none(self):
+        assert dc._safe_float("abc") is None
+        assert dc._safe_float({}) is None
+
+    def test_strips_thousands_comma(self):
+        assert dc._safe_float("79,140,503,000,000") == 79_140_503_000_000.0
+
+
+def _make_dart_df(rows: list[dict]) -> pd.DataFrame:
+    return pd.DataFrame(rows)
+
+
+class TestExtractDartAmount:
+    def test_account_id_match_takes_priority(self):
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": "200"},
+            {"sj_div": "IS", "account_id": "dart_OtherSales", "account_nm": "기타매출", "thstrm_amount": "999"},
+        ])
+        assert dc._extract_dart_amount(df, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) == 200.0
+
+    def test_falls_back_to_account_nm_when_no_id_match(self):
+        df = _make_dart_df([
+            {"sj_div": "IS", "account_id": "custom_kgaap_revenue", "account_nm": "매출액", "thstrm_amount": "150"},
+        ])
+        assert dc._extract_dart_amount(df, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) == 150.0
+
+    def test_filters_by_sj_div(self):
+        df = _make_dart_df([
+            {"sj_div": "CF", "account_id": "x", "account_nm": "영업이익", "thstrm_amount": "999"},
+        ])
+        assert dc._extract_dart_amount(df, (), dc._OPERATING_INCOME_KEYWORDS, sj_divs=("IS",)) is None
+        assert dc._extract_dart_amount(df, (), dc._OPERATING_INCOME_KEYWORDS, sj_divs=("CF",)) == 999.0
+
+    def test_handles_missing_columns_safely(self):
+        df = pd.DataFrame({"sj_div": ["IS"], "thstrm_amount": ["100"]})
+        assert dc._extract_dart_amount(df, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) is None
+
+    def test_handles_empty_dataframe(self):
+        assert dc._extract_dart_amount(pd.DataFrame(), dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) is None
+        assert dc._extract_dart_amount(None, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
+
+    def test_handles_dict_response_from_dart_no_data(self):
+        no_data = {"status": "013", "message": "조회된 데이타가 없습니다."}
+        assert dc._extract_dart_amount(no_data, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
+
+    def test_prefers_thstrm_add_amount_for_is_rows(self):
+        """IS rows: thstrm_amount = 단일 분기, thstrm_add_amount = 누적. add 우선."""
+        df = _make_dart_df([{
+            "sj_div": "IS",
+            "account_id": "ifrs-full_Revenue",
+            "account_nm": "매출액",
+            "thstrm_amount": "74,566,317,000,000",
+            "thstrm_add_amount": "153,706,820,000,000",
+        }])
+        assert dc._extract_dart_amount(df, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) == 153_706_820_000_000.0
+
+    def test_falls_back_to_thstrm_amount_when_add_empty(self):
+        """FY 보고서 / Q1 / CF rows: thstrm_add_amount 비어있음 → amount 가 누적."""
+        df_fy = _make_dart_df([{
+            "sj_div": "IS",
+            "account_id": "ifrs-full_Revenue",
+            "account_nm": "매출액",
+            "thstrm_amount": "333,605,938,000,000",
+            "thstrm_add_amount": "",
+        }])
+        assert dc._extract_dart_amount(df_fy, dc._REVENUE_IDS, dc._REVENUE_KEYWORDS) == 333_605_938_000_000.0
+
+        df_cf = _make_dart_df([{
+            "sj_div": "CF",
+            "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities",
+            "account_nm": "영업활동현금흐름",
+            "thstrm_amount": "33,941,002,000,000",
+            "thstrm_add_amount": float("nan"),
+        }])
+        assert dc._extract_dart_amount(df_cf, dc._OPERATING_CF_IDS, dc._OPERATING_CF_KEYWORDS, sj_divs=("CF",)) == 33_941_002_000_000.0
+
+    def test_treats_zero_thstrm_add_amount_as_valid(self):
+        """add_amount = 0 도 valid 누적치 — amount 로 fallback 하면 차분 결과 오염."""
+        df = _make_dart_df([{
+            "sj_div": "CF",
+            "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities",
+            "account_nm": "투자활동현금흐름",
+            "thstrm_amount": "999",
+            "thstrm_add_amount": "0",
+        }])
+        assert dc._extract_dart_amount(df, dc._INVESTING_CF_IDS, dc._INVESTING_CF_KEYWORDS, sj_divs=("CF",)) == 0.0
+
+
+# ---------------------------------------------------------------------------
+# fetch_finstate_extracted — cache + retry layer
+# ---------------------------------------------------------------------------
+
+
+def _build_finstate_df(
+    revenue_cum: float, op_cum: float, net_cum: float,
+    op_cf_cum: float, inv_cf_cum: float, fin_cf_cum: float,
+) -> pd.DataFrame:
+    return _make_dart_df([
+        {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": str(revenue_cum)},
+        {"sj_div": "IS", "account_id": "dart_OperatingIncomeLoss", "account_nm": "영업이익", "thstrm_amount": str(op_cum)},
+        {"sj_div": "IS", "account_id": "ifrs-full_ProfitLoss", "account_nm": "분기순이익", "thstrm_amount": str(net_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities", "account_nm": "영업활동현금흐름", "thstrm_amount": str(op_cf_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities", "account_nm": "투자활동현금흐름", "thstrm_amount": str(inv_cf_cum)},
+        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInFinancingActivities", "account_nm": "재무활동현금흐름", "thstrm_amount": str(fin_cf_cum)},
+    ])
+
+
+@pytest.fixture
+def fake_cache(monkeypatch):
+    """In-memory cache stub backing the redis client."""
+    storage: dict[str, Any] = {}
+    client = MagicMock()
+    client.get = AsyncMock(side_effect=lambda key: storage.get(key))
+
+    async def _set(key, value, ttl=None):
+        storage[key] = value
+        client.last_ttl = ttl
+        return True
+
+    client.set = AsyncMock(side_effect=_set)
+    client.last_ttl = None
+    monkeypatch.setattr(dc, "get_cache_client", lambda: client)
+    return client, storage
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_returns_none_when_no_client(monkeypatch, fake_cache):
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: None)
+    result = await dc.fetch_finstate_extracted("005930", 2025, "11013")
+    assert result is None
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_caches_extracted_values(monkeypatch, fake_cache):
+    """First call hits DART, second call serves from cache (no DART hit)."""
+    cache_client, storage = fake_cache
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(return_value=_build_finstate_df(100, 10, 8, 20, -15, -3))
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    # First call — MISS → DART hit → cache
+    first = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert first == {
+        "revenue": 100.0,
+        "operatingIncome": 10.0,
+        "netIncome": 8.0,
+        "operatingCashFlow": 20.0,
+        "investingCashFlow": -15.0,
+        "financingCashFlow": -3.0,
+    }
+    assert fake_dart.finstate_all.call_count == 1
+    assert "dart:finstate:005930:2024:11013:CFS" in storage
+
+    # Second call — HIT → no DART hit
+    second = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert second == first
+    assert fake_dart.finstate_all.call_count == 1
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_uses_long_ttl_for_past_year(monkeypatch, fake_cache):
+    """Past-year filings are immutable — cache for ~1 year."""
+    cache_client, _storage = fake_cache
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(return_value=_build_finstate_df(100, 10, 8, 20, -15, -3))
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    # Pin "current year" to 2026 so 2024 is firmly in the past.
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2026, 6, 1, tzinfo=tz)
+    monkeypatch.setattr(dc, "datetime", FixedDatetime)
+
+    await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    # Past year + has_data → 1 year TTL
+    assert cache_client.last_ttl == dc._TTL_PAST_YEAR_S
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_uses_short_ttl_for_current_year(monkeypatch, fake_cache):
+    """Current-year filings can land mid-year — cache for ~1 day."""
+    cache_client, _storage = fake_cache
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(return_value=_build_finstate_df(100, 10, 8, 20, -15, -3))
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(2026, 6, 1, tzinfo=tz)
+    monkeypatch.setattr(dc, "datetime", FixedDatetime)
+
+    await dc.fetch_finstate_extracted("005930", 2026, "11013")
+    assert cache_client.last_ttl == dc._TTL_CURRENT_YEAR_S
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_caches_negative_result(monkeypatch, fake_cache):
+    """Genuine 'no data' answers are cached too (shorter TTL)."""
+    cache_client, _storage = fake_cache
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(return_value=pd.DataFrame())
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    result = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert result == dc._EMPTY_EXTRACT
+    # Negative + past year → 7-day TTL
+    assert cache_client.last_ttl == dc._NEG_TTL_PAST_YEAR_S
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_retries_on_exception(monkeypatch, fake_cache, fast_retry):
+    """Two DART exceptions then success — caller never sees failure."""
+    fake_dart = MagicMock()
+    successful_df = _build_finstate_df(100, 10, 8, 20, -15, -3)
+    fake_dart.finstate_all = MagicMock(side_effect=[
+        RuntimeError("DART rate limit"),
+        RuntimeError("network glitch"),
+        successful_df,
+    ])
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    result = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert result is not None
+    assert result["revenue"] == 100.0
+    assert fake_dart.finstate_all.call_count == 3
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_returns_empty_on_retry_exhaustion(monkeypatch, fake_cache, fast_retry):
+    """All retries fail → return _EMPTY_EXTRACT, do NOT cache (next call retries)."""
+    cache_client, storage = fake_cache
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(side_effect=RuntimeError("DART down"))
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    result = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert result == dc._EMPTY_EXTRACT
+    # 1 initial + 3 retries
+    assert fake_dart.finstate_all.call_count == 4
+    # Failure path doesn't cache — so the next call retries from scratch
+    assert "dart:finstate:005930:2024:11013:CFS" not in storage
+
+
+@pytest.mark.asyncio
+async def test_fetch_finstate_extracted_cache_hit_skips_retry_path(monkeypatch, fake_cache, fast_retry):
+    """Cache hit short-circuits before the DART client is even consulted."""
+    cache_client, storage = fake_cache
+    storage["dart:finstate:005930:2024:11013:CFS"] = {
+        "revenue": 42.0,
+        "operatingIncome": None,
+        "netIncome": None,
+        "operatingCashFlow": None,
+        "investingCashFlow": None,
+        "financingCashFlow": None,
+    }
+    fake_dart = MagicMock()
+    fake_dart.finstate_all = MagicMock(side_effect=AssertionError("should not be called"))
+    monkeypatch.setattr(dc, "_get_dart_client", lambda: fake_dart)
+
+    result = await dc.fetch_finstate_extracted("005930", 2024, "11013")
+    assert result is not None
+    assert result["revenue"] == 42.0
+    fake_dart.finstate_all.assert_not_called()

--- a/tests/unit/data_client/korean/test_fundamentals_source.py
+++ b/tests/unit/data_client/korean/test_fundamentals_source.py
@@ -1,15 +1,15 @@
-"""
-Tests for KoreanFundamentalsSource (issue #42).
+"""Tests for KoreanFundamentalsSource (issue #42 + #52).
 
-External calls (yfinance fast_info, pykrx OHLCV, DART finstate) 은 module-level
-helper 로 분리해뒀으니 monkeypatch 로 deterministic mock. integration 검증
-(실제 yf/pykrx/DART hit) 은 별도 — 외부 의존이라 unit suite 에 포함 안 함.
+External calls (yfinance fast_info, pykrx OHLCV, DART) live in module-level
+helpers so they can be ``monkeypatch.setattr`` 'd. DART access goes through
+``dart_client.fetch_finstate_extracted`` (cache + retry layer); these tests
+mock that single async function. dart_client's own internals (cache, retry,
+extract) have dedicated tests in ``test_dart_client.py``.
+
+Integration with real yf/pykrx/DART is out of scope for the unit suite.
 """
 
 from __future__ import annotations
-
-from typing import Any
-from unittest.mock import MagicMock
 
 import pandas as pd
 import pytest
@@ -17,11 +17,33 @@ import pytest
 from src.data_client.korean import fundamentals_source as fs
 
 
-@pytest.fixture(autouse=True)
-def _reset_dart_singleton(monkeypatch):
-    """DART 모듈 싱글톤은 테스트 격리 — 매 테스트 fresh state 로 시작."""
-    monkeypatch.setattr(fs, "_dart_singleton", None)
-    monkeypatch.setattr(fs, "_dart_init_attempted", False)
+def _make_extracted(
+    revenue: float | None = None,
+    op: float | None = None,
+    net: float | None = None,
+    op_cf: float | None = None,
+    inv_cf: float | None = None,
+    fin_cf: float | None = None,
+) -> dict[str, float | None]:
+    """Build a six-key extracted dict in the shape ``fetch_finstate_extracted`` returns."""
+    return {
+        "revenue": revenue,
+        "operatingIncome": op,
+        "netIncome": net,
+        "operatingCashFlow": op_cf,
+        "investingCashFlow": inv_cf,
+        "financingCashFlow": fin_cf,
+    }
+
+
+def _patch_fixed_kst(monkeypatch, year: int, month: int = 12, day: int = 31) -> None:
+    """Pin ``fs.datetime`` so quarterly/annual lookback windows are deterministic."""
+    import datetime as _dt
+    class FixedDatetime(_dt.datetime):
+        @classmethod
+        def now(cls, tz=None):
+            return _dt.datetime(year, month, day, tzinfo=tz)
+    monkeypatch.setattr(fs, "datetime", FixedDatetime)
 
 
 # ---------------------------------------------------------------------------
@@ -42,34 +64,28 @@ class TestSupports:
 
 
 # ---------------------------------------------------------------------------
-# get_overview() — quote + performance 통합
+# get_overview() — quote + performance + DART 통합
 # ---------------------------------------------------------------------------
 
 @pytest.mark.asyncio
 async def test_get_overview_returns_quote_and_performance(monkeypatch):
-    """yf + pykrx 정상 응답 시 quote + performance 합쳐진 dict 반환."""
     fake_quote = {
-        "price": 75000.0,
-        "change": 500.0,
-        "changePct": 0.67,
-        "open": 74500.0,
-        "previousClose": 74500.0,
-        "dayLow": 74400.0,
-        "dayHigh": 75200.0,
-        "yearLow": 60000.0,
-        "yearHigh": 88000.0,
-        "volume": 12_000_000.0,
-        "marketCap": 500_000_000_000_000.0,
-        "shares": 6_700_000_000.0,
-        "pe": None,
-        "eps": None,
+        "price": 75000.0, "change": 500.0, "changePct": 0.67,
+        "open": 74500.0, "previousClose": 74500.0,
+        "dayLow": 74400.0, "dayHigh": 75200.0,
+        "yearLow": 60000.0, "yearHigh": 88000.0,
+        "volume": 12_000_000.0, "marketCap": 500_000_000_000_000.0,
+        "shares": 6_700_000_000.0, "pe": None, "eps": None,
     }
     fake_perf = {"1D": 0.67, "5D": 1.5, "1M": 3.2, "3M": -2.1, "6M": 5.0, "1Y": 25.0, "YTD": 10.0}
 
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: fake_quote)
     monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: fake_perf)
-    # DART 미설정 시나리오 — fundamentals/cashFlow 빈 응답
-    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: ([], []))
+
+    async def empty_quarterlies(_corp): return ([], [])
+    async def empty_annuals(_corp): return ([], [])
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", empty_quarterlies)
+    monkeypatch.setattr(fs, "_fetch_dart_annuals", empty_annuals)
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("005930.KS")
@@ -77,51 +93,55 @@ async def test_get_overview_returns_quote_and_performance(monkeypatch):
     assert result["symbol"] == "005930.KS"
     assert result["quote"] == fake_quote
     assert result["performance"] == fake_perf
-    # 본 PR 에서 채우지 않는 필드는 None — frontend 가 빈 카드 안전 렌더
     assert result["analystRatings"] is None
     assert result["quarterlyFundamentals"] is None
     assert result["cashFlow"] is None
+    assert result["annualFundamentals"] is None
+    assert result["annualCashFlow"] is None
 
 
 @pytest.mark.asyncio
 async def test_get_overview_strips_whitespace_from_symbol(monkeypatch):
-    """공백 포함 호출 시 ticker / symbol_upper 모두 깨끗하게 정규화 — supports() 와 일관."""
     captured: dict[str, str] = {}
 
-    def capture_quote(sym: str) -> dict[str, float]:
+    def capture_quote(sym):
         captured["yf_symbol"] = sym
         return {"price": 1.0}
 
-    def capture_perf(ticker: str) -> dict[str, float]:
+    def capture_perf(ticker):
         captured["pykrx_ticker"] = ticker
         return {"1D": 0.0}
 
-    def capture_dart(corp: str) -> tuple[list, list]:
-        captured["dart_corp"] = corp
+    async def capture_quarterlies(corp):
+        captured["dart_quarterly_corp"] = corp
+        return ([], [])
+
+    async def capture_annuals(corp):
+        captured["dart_annual_corp"] = corp
         return ([], [])
 
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", capture_quote)
     monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", capture_perf)
-    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", capture_dart)
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", capture_quarterlies)
+    monkeypatch.setattr(fs, "_fetch_dart_annuals", capture_annuals)
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("  005930.KS  ")
 
-    # symbol/ticker 모두 strip 됐는지 — 공백이 외부 호출까지 leak 안 돼야
     assert captured["yf_symbol"] == "005930.KS"
     assert captured["pykrx_ticker"] == "005930"
-    assert captured["dart_corp"] == "005930"
+    assert captured["dart_quarterly_corp"] == "005930"
+    assert captured["dart_annual_corp"] == "005930"
     assert result["symbol"] == "005930.KS"
 
 
 @pytest.mark.asyncio
 async def test_get_overview_yf_fail_returns_partial(monkeypatch):
-    """yf 호출 실패 (빈 dict) 면 _partial=True — caller 가 unsupported 응답으로 fallback."""
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: {})
-    monkeypatch.setattr(
-        fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 1.0}
-    )
-    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: ([], []))
+    monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 1.0})
+    async def empty(_corp): return ([], [])
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", empty)
+    monkeypatch.setattr(fs, "_fetch_dart_annuals", empty)
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("005930.KS")
@@ -132,51 +152,59 @@ async def test_get_overview_yf_fail_returns_partial(monkeypatch):
 
 
 @pytest.mark.asyncio
-async def test_get_overview_includes_dart_quarterly_data(monkeypatch):
-    """DART 정상 응답 시 quarterlyFundamentals + cashFlow 가 overview 에 포함."""
+async def test_get_overview_includes_dart_quarterly_and_annual_data(monkeypatch):
     fundamentals = [
-        {"period": "2025 Q3", "revenue": 80_000_000_000_000.0, "operatingIncome": 9_000_000_000_000.0, "netIncome": 7_000_000_000_000.0},
-        {"period": "2025 Q4", "revenue": 85_000_000_000_000.0, "operatingIncome": 10_500_000_000_000.0, "netIncome": 8_000_000_000_000.0},
+        {"period": "2025 Q3", "revenue": 80e12, "operatingIncome": 9e12, "netIncome": 7e12},
+        {"period": "2025 Q4", "revenue": 85e12, "operatingIncome": 10.5e12, "netIncome": 8e12},
     ]
     cashflow = [
-        {"period": "2025 Q3", "operatingCashFlow": 12_000_000_000_000.0, "investingCashFlow": -8_000_000_000_000.0, "financingCashFlow": -3_000_000_000_000.0},
-        {"period": "2025 Q4", "operatingCashFlow": 14_000_000_000_000.0, "investingCashFlow": -9_500_000_000_000.0, "financingCashFlow": -3_500_000_000_000.0},
+        {"period": "2025 Q3", "operatingCashFlow": 12e12, "investingCashFlow": -8e12, "financingCashFlow": -3e12},
+        {"period": "2025 Q4", "operatingCashFlow": 14e12, "investingCashFlow": -9.5e12, "financingCashFlow": -3.5e12},
+    ]
+    annual_funds = [
+        {"period": "2023", "revenue": 250e12, "operatingIncome": 6e12, "netIncome": 15e12},
+        {"period": "2024", "revenue": 300e12, "operatingIncome": 32e12, "netIncome": 25e12},
+    ]
+    annual_cf = [
+        {"period": "2023", "operatingCashFlow": 50e12, "investingCashFlow": -30e12, "financingCashFlow": -10e12},
+        {"period": "2024", "operatingCashFlow": 60e12, "investingCashFlow": -35e12, "financingCashFlow": -12e12},
     ]
     monkeypatch.setattr(fs, "_fetch_quote_from_yf", lambda symbol: {"price": 75000.0})
     monkeypatch.setattr(fs, "_fetch_performance_from_pykrx", lambda ticker: {"1D": 0.5})
-    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", lambda corp: (fundamentals, cashflow))
+    async def quarterlies(_corp): return (fundamentals, cashflow)
+    async def annuals(_corp): return (annual_funds, annual_cf)
+    monkeypatch.setattr(fs, "_fetch_dart_quarterlies", quarterlies)
+    monkeypatch.setattr(fs, "_fetch_dart_annuals", annuals)
 
     source = fs.KoreanFundamentalsSource()
     result = await source.get_overview("005930.KS")
 
     assert result["quarterlyFundamentals"] == fundamentals
     assert result["cashFlow"] == cashflow
+    assert result["annualFundamentals"] == annual_funds
+    assert result["annualCashFlow"] == annual_cf
 
 
 # ---------------------------------------------------------------------------
-# _fetch_performance_from_pykrx() — % 계산 logic
+# _fetch_performance_from_pykrx
 # ---------------------------------------------------------------------------
 
-def _make_ohlcv_df(closes: list[float], freq: str = "B") -> pd.DataFrame:
-    """Mock pykrx OHLCV DataFrame — '종가' column 만 채움 (계산에 충분)."""
-    idx = pd.date_range(end="2026-04-27", periods=len(closes), freq=freq, name="날짜")
+def _make_ohlcv_df(closes: list[float]) -> pd.DataFrame:
+    idx = pd.date_range(end="2026-04-27", periods=len(closes), freq="B", name="날짜")
     return pd.DataFrame({"종가": closes}, index=idx)
 
 
 def test_performance_computes_percentage_against_lookback(monkeypatch):
-    # 마지막 종가 100, 1일 전 99, 5일 전 95 → 1D=1.01%, 5D=5.26%
-    # 1Y lookback 은 252 영업일이라 총 260+ bars 필요.
     closes = [80.0] * 260 + [95.0, 96.0, 97.0, 98.0, 99.0, 100.0]
     monkeypatch.setattr(fs.stock, "get_market_ohlcv", lambda *a, **k: _make_ohlcv_df(closes))
 
     perf = fs._fetch_performance_from_pykrx("005930")
     assert perf["1D"] == pytest.approx((100 - 99) / 99 * 100, abs=0.01)
     assert perf["5D"] == pytest.approx((100 - 95) / 95 * 100, abs=0.01)
-    assert perf["1Y"] is not None  # 252+ bars 있음
+    assert perf["1Y"] is not None
 
 
 def test_performance_returns_none_when_insufficient_data(monkeypatch):
-    # 짧은 시계열 — 1D 만 가능, 나머지는 None
     monkeypatch.setattr(
         fs.stock, "get_market_ohlcv", lambda *a, **k: _make_ohlcv_df([100.0, 101.0])
     )
@@ -189,7 +217,6 @@ def test_performance_returns_none_when_insufficient_data(monkeypatch):
 def test_performance_returns_all_none_on_pykrx_failure(monkeypatch):
     def boom(*args, **kwargs):
         raise RuntimeError("KRX site down")
-
     monkeypatch.setattr(fs.stock, "get_market_ohlcv", boom)
     perf = fs._fetch_performance_from_pykrx("005930")
     assert all(v is None for v in perf.values())
@@ -202,10 +229,7 @@ def test_performance_returns_all_none_on_empty_df(monkeypatch):
 
 
 def test_performance_returns_all_none_when_close_column_missing(monkeypatch):
-    """pykrx schema 변경 / mock 결함으로 '종가' column 이 빠진 DataFrame 도 안전 처리.
-
-    회귀 방지 — 직접 df["종가"] 인덱싱은 KeyError 로 /overview 전체 500 으로 번짐.
-    """
+    """Regression: direct df["종가"] indexing would propagate KeyError into 500."""
     df_no_close = pd.DataFrame({"시가": [100.0, 101.0], "거래량": [10, 20]})
     monkeypatch.setattr(fs.stock, "get_market_ohlcv", lambda *a, **k: df_no_close)
     perf = fs._fetch_performance_from_pykrx("005930")
@@ -213,353 +237,108 @@ def test_performance_returns_all_none_when_close_column_missing(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# _safe_float — NaN / None / non-numeric 처리
+# _fetch_dart_quarterlies — 누적 → 분기 차분
 # ---------------------------------------------------------------------------
 
-class TestSafeFloat:
-    def test_valid_numeric(self):
-        assert fs._safe_float(1.5) == 1.5
-        assert fs._safe_float(0) == 0.0
-        assert fs._safe_float("3.14") == 3.14
-
-    def test_none_returns_none(self):
-        assert fs._safe_float(None) is None
-
-    def test_nan_returns_none(self):
-        assert fs._safe_float(float("nan")) is None
-
-    def test_non_numeric_returns_none(self):
-        assert fs._safe_float("abc") is None
-        assert fs._safe_float({}) is None
-
-
-# ---------------------------------------------------------------------------
-# _extract_dart_amount — DART finstate row 매칭
-# ---------------------------------------------------------------------------
-
-
-def _make_dart_df(rows: list[dict]) -> pd.DataFrame:
-    """DART finstate-shape DataFrame helper."""
-    return pd.DataFrame(rows)
-
-
-class TestExtractDartAmount:
-    def test_account_id_match_takes_priority(self):
-        # account_id 와 account_nm 둘 다 있을 때 account_id 매칭 우선.
-        df = _make_dart_df([
-            {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": "200"},
-            {"sj_div": "IS", "account_id": "dart_OtherSales", "account_nm": "기타매출", "thstrm_amount": "999"},
-        ])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 200.0
-
-    def test_falls_back_to_account_nm_when_no_id_match(self):
-        # account_id 매칭 실패 → account_nm substring 으로 fallback (K-GAAP 회사 등).
-        df = _make_dart_df([
-            {"sj_div": "IS", "account_id": "custom_kgaap_revenue", "account_nm": "매출액", "thstrm_amount": "150"},
-        ])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 150.0
-
-    def test_substring_match_alternate_revenue_label(self):
-        df = _make_dart_df([
-            {"sj_div": "IS", "account_id": "x", "account_nm": "영업수익", "thstrm_amount": "300"},
-        ])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 300.0
-
-    def test_returns_none_when_no_match(self):
-        df = _make_dart_df([
-            {"sj_div": "IS", "account_id": "x", "account_nm": "기타수익", "thstrm_amount": "50"},
-        ])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
-
-    def test_filters_by_sj_div(self):
-        # CF 에서 영업이익 키워드 — IS 에만 한정하면 None
-        df = _make_dart_df([
-            {"sj_div": "CF", "account_id": "x", "account_nm": "영업이익", "thstrm_amount": "999"},
-        ])
-        assert fs._extract_dart_amount(df, (), fs._OPERATING_INCOME_KEYWORDS, sj_divs=("IS",)) is None
-        assert fs._extract_dart_amount(df, (), fs._OPERATING_INCOME_KEYWORDS, sj_divs=("CF",)) == 999.0
-
-    def test_handles_comma_formatted_amounts(self):
-        # finstate (legacy) 는 thstrm_amount 가 천단위 콤마 string
-        df = _make_dart_df([
-            {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": "79,140,503,000,000"},
-        ])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 79_140_503_000_000.0
-
-    def test_handles_missing_columns_safely(self):
-        # account_nm / account_id column 누락 — KeyError 대신 None
-        df = pd.DataFrame({"sj_div": ["IS"], "thstrm_amount": ["100"]})
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
-
-    def test_handles_empty_dataframe(self):
-        assert fs._extract_dart_amount(pd.DataFrame(), fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None
-        assert fs._extract_dart_amount(None, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
-
-    def test_handles_dict_response_from_dart_no_data(self):
-        # OpenDartReader 가 'no data' 시 dict 반환하는 케이스 — DataFrame 아님 → None
-        no_data = {"status": "013", "message": "조회된 데이타가 없습니다."}
-        assert fs._extract_dart_amount(no_data, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) is None  # type: ignore[arg-type]
-
-    def test_prefers_thstrm_add_amount_for_is_rows(self):
-        """IS rows: thstrm_amount 는 단일 분기 (3M), thstrm_add_amount 는 연초 누적.
-
-        회귀 방지 — H1 보고서의 thstrm_amount (74,566억) 를 잘못 누적치로 쓰면
-        Q2 = H1 - Q1 = 음수가 나옴. 누적치 (thstrm_add_amount=153,706억) 우선.
-        """
-        df = _make_dart_df([{
-            "sj_div": "IS",
-            "account_id": "ifrs-full_Revenue",
-            "account_nm": "매출액",
-            "thstrm_amount": "74,566,317,000,000",
-            "thstrm_add_amount": "153,706,820,000,000",
-        }])
-        # add_amount = H1 cumulative — 누적치 우선
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 153_706_820_000_000.0
-
-    def test_falls_back_to_thstrm_amount_when_add_empty(self):
-        """FY 보고서 / Q1 보고서 / CF rows: thstrm_add_amount 비어있음 → amount 가 누적."""
-        df = _make_dart_df([{
-            "sj_div": "IS",
-            "account_id": "ifrs-full_Revenue",
-            "account_nm": "매출액",
-            "thstrm_amount": "333,605,938,000,000",
-            "thstrm_add_amount": "",  # FY report — add 비어있음
-        }])
-        assert fs._extract_dart_amount(df, fs._REVENUE_IDS, fs._REVENUE_KEYWORDS) == 333_605_938_000_000.0
-
-        df_cf = _make_dart_df([{
-            "sj_div": "CF",
-            "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities",
-            "account_nm": "영업활동현금흐름",
-            "thstrm_amount": "33,941,002,000,000",
-            "thstrm_add_amount": float("nan"),
-        }])
-        assert fs._extract_dart_amount(df_cf, fs._OPERATING_CF_IDS, fs._OPERATING_CF_KEYWORDS, sj_divs=("CF",)) == 33_941_002_000_000.0
-
-    def test_treats_zero_thstrm_add_amount_as_valid(self):
-        """add_amount = 0 도 valid 누적치 — amount 로 fallback 하면 안 됨.
-
-        회귀 방지 — 이전엔 ``add_val != 0`` guard 로 정확히 0 인 cumulative 가
-        falsey 로 취급돼 thstrm_amount (단일 분기) 로 fallback. 차분 logic 이
-        틀어져 다음 분기 계산 결과까지 오염됨.
-        """
-        df = _make_dart_df([{
-            "sj_div": "CF",
-            "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities",
-            "account_nm": "투자활동현금흐름",
-            "thstrm_amount": "999",      # 만약 fallback 되면 이 값 반환
-            "thstrm_add_amount": "0",    # cumulative = 0 (정확히 0 인 분기)
-        }])
-        result = fs._extract_dart_amount(df, fs._INVESTING_CF_IDS, fs._INVESTING_CF_KEYWORDS, sj_divs=("CF",))
-        assert result == 0.0
-
-
-def test_fetch_dart_quarterlies_recovers_n_minus_2_q4_when_prior_year_fy_missing(monkeypatch):
-    """연초 (FY 미공시) 시나리오 — 직전-1 Q4 까지 거슬러 quarters[-4:] 4개 확보.
-
-    회귀 방지 — years 가 (N-1, N) 만 fetch 하면 1~3월 (FY 마감 90일 전) 에는
-    직전 해 FY 누락으로 Q4 못 만들고, 결과적으로 quarters 가 3개 (Q1/Q2/Q3) 만
-    돼서 frontend 분기 차트가 비어있는 분기 칸으로 보임.
-    """
-    # 시나리오: today = 2026-02-01 (이른 연초). 2025 FY 아직 미공시.
-    # 2025 Q1/H1/9M 만 공시, 2024 는 모두 공시 완료.
-    full_year = lambda mult=1: _build_finstate_df(  # noqa: E731
-        100 * mult, 10 * mult, 8 * mult, 20 * mult, -15 * mult, -3 * mult,
-    )
-    h1 = lambda mult=1: _build_finstate_df(  # noqa: E731
-        250 * mult, 28 * mult, 22 * mult, 50 * mult, -38 * mult, -8 * mult,
-    )
-    nine_m = lambda mult=1: _build_finstate_df(  # noqa: E731
-        400 * mult, 48 * mult, 38 * mult, 80 * mult, -60 * mult, -13 * mult,
-    )
-    fy = lambda mult=1: _build_finstate_df(  # noqa: E731
-        600 * mult, 75 * mult, 60 * mult, 120 * mult, -90 * mult, -20 * mult,
-    )
-
-    def finstate_all(corp, year, reprt_code):
-        # 2024: 전부 공시
-        if year == 2024:
-            return {"11013": full_year(1), "11012": h1(1), "11014": nine_m(1), "11011": fy(1)}.get(reprt_code)
-        # 2025: Q1/H1/9M 만 공시 (FY 아직 안 나옴)
-        if year == 2025:
-            return {"11013": full_year(2), "11012": h1(2), "11014": nine_m(2)}.get(reprt_code)
+@pytest.mark.asyncio
+async def test_fetch_dart_quarterlies_returns_empty_when_no_client(monkeypatch):
+    """``fetch_finstate_extracted`` returns None (no API key) → degrade gracefully."""
+    async def no_dart(*_args, **_kwargs):
         return None
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", no_dart)
 
-    fake_dart = MagicMock()
-    fake_dart.finstate_all = finstate_all
-    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
-
-    import datetime as _dt
-    class FixedDatetime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return _dt.datetime(2026, 2, 1, tzinfo=tz)
-    monkeypatch.setattr(fs, "datetime", FixedDatetime)
-
-    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
-
-    # quarters[-4:] = 2024 Q4 + 2025 Q1/Q2/Q3 — 4개 확보
-    periods = [q["period"] for q in fundamentals]
-    assert periods == ["2024 Q4", "2025 Q1", "2025 Q2", "2025 Q3"]
-    # 2024 Q4 = FY - 9M = (600 - 400) = 200
-    assert fundamentals[0]["revenue"] == 200.0
-    # 2025 Q1 = mult 2 → 200
-    assert fundamentals[1]["revenue"] == 200.0
-
-
-def test_get_dart_client_lock_prevents_concurrent_init_returning_none(monkeypatch):
-    """동시 호출 시 init 중인 thread 외 다른 thread 가 미완성 None 받지 않음.
-
-    회귀 방지 — 이전엔 init_attempted 를 OpenDartReader instantiate 전에 set 했고,
-    instantiate 가 수초 걸리는 동안 다른 thread 들이 None 을 받아 fundamentals
-    데이터 누락. Lock + flag-after-init 로 모든 thread 가 같은 결과 봄.
-    """
-    import threading as _threading
-    monkeypatch.setenv("DART_API_KEY", "fake-key")
-    init_call_count = 0
-    init_started = _threading.Event()
-    init_can_finish = _threading.Event()
-
-    class SlowOpenDartReader:
-        def __init__(self, key):
-            nonlocal init_call_count
-            init_call_count += 1
-            init_started.set()
-            init_can_finish.wait(timeout=2)
-
-    import sys
-    fake_module = type(sys)("OpenDartReader")
-    fake_module.__call__ = SlowOpenDartReader
-    # OpenDartReader 는 모듈명도 클래스명도 OpenDartReader — `import OpenDartReader; OpenDartReader(key)`
-    # 패턴이라 모듈을 callable 로 만들기 보다 sys.modules 통째로 mock.
-    sys.modules["OpenDartReader"] = SlowOpenDartReader  # type: ignore[assignment]
-
-    results: list[Any] = []
-
-    def call_get_client():
-        results.append(fs._get_dart_client())
-
-    t1 = _threading.Thread(target=call_get_client)
-    t2 = _threading.Thread(target=call_get_client)
-    t1.start()
-    init_started.wait(timeout=2)  # t1 이 instantiate 진입할 때까지 대기
-    t2.start()  # t2 는 lock 에서 wait 해야 함
-    init_can_finish.set()
-    t1.join(timeout=3)
-    t2.join(timeout=3)
-
-    # init 은 정확히 1번만, 두 thread 모두 같은 instance 받음 (None 없음).
-    assert init_call_count == 1
-    assert all(r is not None for r in results), f"got None during concurrent init: {results}"
-    assert results[0] is results[1]
-
-    # cleanup: sys.modules 복원
-    del sys.modules["OpenDartReader"]
-
-
-# ---------------------------------------------------------------------------
-# _fetch_dart_quarterlies — 누적 → 분기 차분 + DART 가용성 분기
-# ---------------------------------------------------------------------------
-
-
-def _build_finstate_df(
-    revenue_cum: float, op_cum: float, net_cum: float,
-    op_cf_cum: float, inv_cf_cum: float, fin_cf_cum: float,
-) -> pd.DataFrame:
-    """누적 금액으로 채운 DART finstate_all-shape DataFrame.
-
-    finstate_all 은 한 호출당 단일 fs_div ("CFS" 또는 "OFS") — fs_div column 없음.
-    account_id (XBRL 표준 ID) 와 account_nm 둘 다 채워서 매칭 fallback 검증.
-    """
-    return _make_dart_df([
-        {"sj_div": "IS", "account_id": "ifrs-full_Revenue", "account_nm": "매출액", "thstrm_amount": str(revenue_cum)},
-        {"sj_div": "IS", "account_id": "dart_OperatingIncomeLoss", "account_nm": "영업이익", "thstrm_amount": str(op_cum)},
-        {"sj_div": "IS", "account_id": "ifrs-full_ProfitLoss", "account_nm": "분기순이익", "thstrm_amount": str(net_cum)},
-        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInOperatingActivities", "account_nm": "영업활동현금흐름", "thstrm_amount": str(op_cf_cum)},
-        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInInvestingActivities", "account_nm": "투자활동현금흐름", "thstrm_amount": str(inv_cf_cum)},
-        {"sj_div": "CF", "account_id": "ifrs-full_CashFlowsFromUsedInFinancingActivities", "account_nm": "재무활동현금흐름", "thstrm_amount": str(fin_cf_cum)},
-    ])
-
-
-def test_fetch_dart_quarterlies_returns_empty_when_no_client(monkeypatch):
-    """DART_API_KEY 미설정 (client=None) 이면 ([], []) — overview 는 정상 응답 유지."""
-    monkeypatch.setattr(fs, "_get_dart_client", lambda: None)
-    fundamentals, cashflow = fs._fetch_dart_quarterlies("005930")
+    fundamentals, cashflow = await fs._fetch_dart_quarterlies("005930")
     assert fundamentals == []
     assert cashflow == []
 
 
-def test_fetch_dart_quarterlies_subtracts_cumulative_to_single_quarter(monkeypatch):
-    """H1/9M/FY 의 누적치를 직전 보고서 빼서 단일 분기 환산."""
-    # 한 해 (year=2025) full data — Q1=100, H1=250 → Q2=150, 9M=400 → Q3=150, FY=600 → Q4=200
+@pytest.mark.asyncio
+async def test_fetch_dart_quarterlies_subtracts_cumulative_to_single_quarter(monkeypatch):
+    """H1/9M/FY 누적치 - 직전 누적 → 단일 분기."""
+    _patch_fixed_kst(monkeypatch, year=2025)
+
     cumulative_by_period = {
-        "11013": _build_finstate_df(100, 10, 8, 20, -15, -3),    # Q1
-        "11012": _build_finstate_df(250, 28, 22, 50, -38, -8),   # H1 cumul
-        "11014": _build_finstate_df(400, 48, 38, 80, -60, -13),  # 9M cumul
-        "11011": _build_finstate_df(600, 75, 60, 120, -90, -20), # FY cumul
+        "11013": _make_extracted(100, 10, 8, 20, -15, -3),    # Q1
+        "11012": _make_extracted(250, 28, 22, 50, -38, -8),   # H1 cumul
+        "11014": _make_extracted(400, 48, 38, 80, -60, -13),  # 9M cumul
+        "11011": _make_extracted(600, 75, 60, 120, -90, -20), # FY cumul
     }
-    fake_dart = MagicMock()
-    # year=2024 (전년) 은 None — 조회는 시도되지만 빈 응답
-    # year=2025 (당해) 만 응답.
 
-    def finstate(corp, year, reprt_code):
+    async def fake_fetch(corp, year, reprt_code, fs_div="CFS"):
+        # 2025 만 응답, 그 외 빈 데이터
         if year != 2025:
-            return None
-        return cumulative_by_period.get(reprt_code)
+            return _make_extracted()
+        return cumulative_by_period.get(reprt_code, _make_extracted())
 
-    fake_dart.finstate_all = finstate
-    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
-    # _KST.now() 의 year 로 fetch 범위 결정 — 2025 가 포함되도록 stub
-    import datetime as _dt
-    class FixedDatetime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return _dt.datetime(2025, 12, 31, tzinfo=tz)
-    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", fake_fetch)
 
-    fundamentals, cashflow = fs._fetch_dart_quarterlies("005930")
+    fundamentals, cashflow = await fs._fetch_dart_quarterlies("005930")
 
-    # 4 quarters expected
     assert len(fundamentals) == 4
     assert [q["period"] for q in fundamentals] == ["2025 Q1", "2025 Q2", "2025 Q3", "2025 Q4"]
-    # Q1 = cumulative
     assert fundamentals[0]["revenue"] == 100.0
-    # Q2 = H1 - Q1 = 250 - 100 = 150
-    assert fundamentals[1]["revenue"] == 150.0
-    # Q3 = 9M - H1 = 400 - 250 = 150
-    assert fundamentals[2]["revenue"] == 150.0
-    # Q4 = FY - 9M = 600 - 400 = 200
-    assert fundamentals[3]["revenue"] == 200.0
+    assert fundamentals[1]["revenue"] == 150.0  # H1 - Q1
+    assert fundamentals[2]["revenue"] == 150.0  # 9M - H1
+    assert fundamentals[3]["revenue"] == 200.0  # FY - 9M
 
-    # cashflow 도 동일 로직으로 차분
     assert cashflow[0]["operatingCashFlow"] == 20.0
-    assert cashflow[1]["operatingCashFlow"] == 30.0  # 50 - 20
+    assert cashflow[1]["operatingCashFlow"] == 30.0
 
 
-def test_fetch_dart_quarterlies_skips_quarter_when_prev_cumulative_missing(monkeypatch):
-    """Q1 보고서 누락 시 Q2 (=H1-Q1) 계산 불가 → skip. Q3/Q4 는 정상."""
-    cumulative_by_period = {
-        # 11013 (Q1) 누락 — Q2 계산 불가
-        "11012": _build_finstate_df(250, 28, 22, 50, -38, -8),
-        "11014": _build_finstate_df(400, 48, 38, 80, -60, -13),
-        "11011": _build_finstate_df(600, 75, 60, 120, -90, -20),
+@pytest.mark.asyncio
+async def test_fetch_dart_quarterlies_recovers_n_minus_2_q4_when_prior_year_fy_missing(monkeypatch):
+    """연초 시나리오 — 직전-1 Q4 까지 거슬러 quarters[-4:] 4개 확보."""
+    _patch_fixed_kst(monkeypatch, year=2026, month=2, day=1)
+
+    full_2024 = {
+        "11013": _make_extracted(100, 10, 8, 20, -15, -3),
+        "11012": _make_extracted(250, 28, 22, 50, -38, -8),
+        "11014": _make_extracted(400, 48, 38, 80, -60, -13),
+        "11011": _make_extracted(600, 75, 60, 120, -90, -20),
     }
-    fake_dart = MagicMock()
-    fake_dart.finstate_all = lambda corp, year, reprt_code: (
-        cumulative_by_period.get(reprt_code) if year == 2025 else None
-    )
-    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
+    partial_2025 = {
+        "11013": _make_extracted(200, 20, 16, 40, -30, -6),
+        "11012": _make_extracted(500, 56, 44, 100, -76, -16),
+        "11014": _make_extracted(800, 96, 76, 160, -120, -26),
+    }
 
-    import datetime as _dt
-    class FixedDatetime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return _dt.datetime(2025, 12, 31, tzinfo=tz)
-    monkeypatch.setattr(fs, "datetime", FixedDatetime)
+    async def fake_fetch(corp, year, reprt_code, fs_div="CFS"):
+        if year == 2024:
+            return full_2024.get(reprt_code, _make_extracted())
+        if year == 2025:
+            return partial_2025.get(reprt_code, _make_extracted())
+        return _make_extracted()
 
-    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", fake_fetch)
 
-    # Q1 자체도 없고 Q2 도 prev 없어서 skip — Q3/Q4 만 (단, Q3 도 H1 가 prev — H1 있으니 가능)
+    fundamentals, _ = await fs._fetch_dart_quarterlies("005930")
+    periods = [q["period"] for q in fundamentals]
+    assert periods == ["2024 Q4", "2025 Q1", "2025 Q2", "2025 Q3"]
+    # 2024 Q4 = FY - 9M = 600 - 400 = 200
+    assert fundamentals[0]["revenue"] == 200.0
+    # 2025 Q1 = 200
+    assert fundamentals[1]["revenue"] == 200.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_dart_quarterlies_skips_quarter_when_prev_cumulative_missing(monkeypatch):
+    """Q1 누락 시 Q2 (=H1-Q1) 계산 불가 → skip. Q3/Q4 는 정상."""
+    _patch_fixed_kst(monkeypatch, year=2025)
+    cumulative_by_period = {
+        # 11013 (Q1) 누락
+        "11012": _make_extracted(250, 28, 22, 50, -38, -8),
+        "11014": _make_extracted(400, 48, 38, 80, -60, -13),
+        "11011": _make_extracted(600, 75, 60, 120, -90, -20),
+    }
+
+    async def fake_fetch(corp, year, reprt_code, fs_div="CFS"):
+        if year != 2025:
+            return _make_extracted()
+        return cumulative_by_period.get(reprt_code, _make_extracted())
+
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", fake_fetch)
+
+    fundamentals, _ = await fs._fetch_dart_quarterlies("005930")
     periods = [q["period"] for q in fundamentals]
     assert "2025 Q1" not in periods
     assert "2025 Q2" not in periods
@@ -567,39 +346,62 @@ def test_fetch_dart_quarterlies_skips_quarter_when_prev_cumulative_missing(monke
     assert "2025 Q4" in periods
 
 
-def test_fetch_dart_quarterlies_handles_finstate_exception(monkeypatch):
-    """finstate 가 예외 raise 해도 다른 보고서 fetch 는 계속 — 일부 분기만 나옴."""
-    fake_dart = MagicMock()
+# ---------------------------------------------------------------------------
+# _fetch_dart_annuals — FY 만 N 년치
+# ---------------------------------------------------------------------------
 
-    def flaky_finstate(corp, year, reprt_code):
-        if reprt_code == "11013":
-            raise RuntimeError("DART rate limit")
-        if year == 2025 and reprt_code == "11012":
-            return _build_finstate_df(250, 28, 22, 50, -38, -8)
-        if year == 2025 and reprt_code == "11014":
-            return _build_finstate_df(400, 48, 38, 80, -60, -13)
+@pytest.mark.asyncio
+async def test_fetch_dart_annuals_returns_year_keyed_series(monkeypatch):
+    """5년 연속 FY 데이터 → 5개 연도 시계열."""
+    _patch_fixed_kst(monkeypatch, year=2025)
+
+    annuals_by_year = {
+        2020: _make_extracted(200, 20, 15, 40, -25, -8),
+        2021: _make_extracted(220, 25, 18, 45, -28, -9),
+        2022: _make_extracted(250, 30, 22, 50, -32, -10),
+        2023: _make_extracted(280, 35, 26, 55, -36, -11),
+        2024: _make_extracted(310, 40, 30, 60, -40, -12),
+    }
+
+    async def fake_fetch(corp, year, reprt_code, fs_div="CFS"):
+        # FY (11011) 만 응답, 그 외 reprt_code 는 호출 안 됨
+        assert reprt_code == "11011"
+        return annuals_by_year.get(year, _make_extracted())
+
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", fake_fetch)
+
+    fundamentals, cashflow = await fs._fetch_dart_annuals("005930", lookback_years=5)
+    # 2020~2024 — 2025 는 _make_extracted() (모두 None) 이라 dropped
+    periods = [r["period"] for r in fundamentals]
+    assert periods == ["2020", "2021", "2022", "2023", "2024"]
+    assert fundamentals[0]["revenue"] == 200.0
+    assert fundamentals[-1]["netIncome"] == 30.0
+    assert cashflow[2]["operatingCashFlow"] == 50.0
+
+
+@pytest.mark.asyncio
+async def test_fetch_dart_annuals_drops_years_with_no_data(monkeypatch):
+    """미공시 연도는 자연스럽게 빠짐 — caller 가 별도 필터 안 해도 됨."""
+    _patch_fixed_kst(monkeypatch, year=2025)
+
+    async def fake_fetch(corp, year, reprt_code, fs_div="CFS"):
+        if year in (2022, 2024):
+            return _make_extracted(year * 1.0)
+        return _make_extracted()  # all None
+
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", fake_fetch)
+
+    fundamentals, _ = await fs._fetch_dart_annuals("005930", lookback_years=5)
+    periods = [r["period"] for r in fundamentals]
+    assert periods == ["2022", "2024"]
+
+
+@pytest.mark.asyncio
+async def test_fetch_dart_annuals_returns_empty_when_no_client(monkeypatch):
+    async def no_dart(*_args, **_kwargs):
         return None
+    monkeypatch.setattr(fs, "fetch_finstate_extracted", no_dart)
 
-    fake_dart.finstate_all = flaky_finstate
-    monkeypatch.setattr(fs, "_get_dart_client", lambda: fake_dart)
-
-    import datetime as _dt
-    class FixedDatetime(_dt.datetime):
-        @classmethod
-        def now(cls, tz=None):
-            return _dt.datetime(2025, 12, 31, tzinfo=tz)
-    monkeypatch.setattr(fs, "datetime", FixedDatetime)
-
-    fundamentals, _ = fs._fetch_dart_quarterlies("005930")
-    # Q1 raise → cumulative 누락 → Q2 skip; 9M 은 H1 prev 있으니 Q3 만 나옴
-    periods = [q["period"] for q in fundamentals]
-    assert periods == ["2025 Q3"]
-
-
-def test_get_dart_client_returns_none_without_api_key(monkeypatch):
-    """DART_API_KEY 환경변수 없으면 client = None — 모듈 import 시 raise 되지 않음."""
-    monkeypatch.delenv("DART_API_KEY", raising=False)
-    # autouse fixture 가 singleton reset 해줌
-    assert fs._get_dart_client() is None
-    # 두 번째 호출도 None — init_attempted flag 동작
-    assert fs._get_dart_client() is None
+    fundamentals, cashflow = await fs._fetch_dart_annuals("005930")
+    assert fundamentals == []
+    assert cashflow == []


### PR DESCRIPTION
## 요약
Closes #52
DART 응답을 Redis 캐시 + retry/backoff 로 감싸고, 연간 사업보고서 시계열 (annualFundamentals / annualCashFlow) 노출.

## 변경 사항

### 새 모듈 `src/data_client/korean/dart_client.py`
- OpenDartReader 싱글톤 (lock + double-checked init) — fundamentals_source 에서 이전
- `fetch_finstate_extracted(stock_code, year, reprt_code, fs_div='CFS')`:
  - Redis 캐시 조회 → MISS 시 DART 호출 → 추출값 캐싱
  - TTL: 과거 연도 1년, 당해 연도 1일 (negative 결과는 7일 / 1시간)
  - 재시도 3회, exponential backoff (1s/2s/4s)
- 추출/매칭 로직 (`_extract_dart_amount`, `_row_cumulative_amount`, `_safe_float`) 도 함께 이전 — DART 응답 처리 한 곳에 모음

### `fundamentals_source.py`
- DART 코드 dart_client 로 이전, async wrapper (`_fetch_dart_quarterlies`) 가 `fetch_finstate_extracted` 를 `asyncio.gather` 로 병렬 호출
- 신규 `_fetch_dart_annuals(stock_code, lookback_years=5)` — FY (11011) 만 N 년치 (캐시 공유로 quarterly 의 FY 와 RTT 0)
- `get_overview` 응답에 `annualFundamentals` + `annualCashFlow` 추가

### 모델 / 라우터
- `CompanyOverviewResponse` 에 `annualFundamentals`, `annualCashFlow` 필드 추가
- `market_data.py` /overview 핸들러에서 새 필드 통과

## 기술적 판단
- **추출값 캐싱 vs 원본 DataFrame 캐싱**: 추출값 (6개 float) 만 캐싱해 페이로드 작고 schema 변경 영향 없음. 새 계정 (gross margin 등) 추가 시 cache schema 확장만 필요한데 그때 가서 처리
- **재시도 vs token bucket**: 단일 사용자 셀프호스팅 환경에서 DART rate limit (분당 1000회) 초과 가능성 매우 낮음. 단발 장애 회복만 보강 (3회 backoff) — token bucket 은 over-engineering
- **annual 별도 호출 추가**: quarterly 파이프라인의 FY 호출과 캐시 키 공유 — `(stock, year, 11011, CFS)` 한 번만 hit, 나머지 0 RTT
- **TTL 차이**: 과거 연도 (immutable) 365일, 당해 연도 (mid-year filing 가능) 1일. negative 결과도 캐시 (burst 방어) 단 짧게 (1시간/7일)

## 검증
- `uv run pytest tests/unit/data_client/korean/ tests/unit/server/app/test_market_data_kr_unsupported.py` — 127 passed
- `uv run ruff check src/data_client/korean/ src/server/ tests/unit/data_client/korean/` — clean

## 별도 이슈로 미루기
- `fs_div=OFS` 별도재무제표 — 지주사 분석 use case 확정 후
- 다종목 batch (`multifinanace.json`) — 스크리너 만들 때


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **New Features**
  * 회사 개요 응답에 연간 재무제표와 연간 현금흐름 데이터 추가
  * 재무 데이터 캐싱 및 재시도 메커니즘으로 성능 개선

* **Tests**
  * 재무 데이터 조회 및 캐싱 로직 검증 추가
  * 분기별 및 연간 재무 정보 처리 테스트 확대

<!-- end of auto-generated comment: release notes by coderabbit.ai -->